### PR TITLE
EW-638: Mark controllers as public temporarily.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,14 +9,6 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=dbildungs-iam
-  dbiam-server:
-    image: dbildungs-iam/dev:latest
-    ports:
-      - 9090:9090
-      - 8443:8443
-    environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
   keycloak:
     image: quay.io/keycloak/keycloak:22.0.3
     environment:

--- a/src/modules/organisation/api/organisation.controller.ts
+++ b/src/modules/organisation/api/organisation.controller.ts
@@ -17,9 +17,11 @@ import { CreateOrganisationDto } from './create-organisation.dto.js';
 import { OrganisationResponse } from './organisation.response.js';
 import { CreatedOrganisationDto } from './created-organisation.dto.js';
 import { OrganisationByIdParams } from './organisation-by-id.params.js';
+import { Public } from 'nest-keycloak-connect';
 
 @ApiTags('organisation')
 @Controller({ path: 'organisation' })
+@Public()
 export class OrganisationController {
     public constructor(
         private readonly uc: OrganisationUc,

--- a/src/modules/person/api/person.controller.ts
+++ b/src/modules/person/api/person.controller.ts
@@ -25,9 +25,11 @@ import { PersonenkontextResponse } from './personenkontext.response.js';
 import { PersonenkontextUc } from './personenkontext.uc.js';
 import { PersonenkontextQueryParams } from './personenkontext-query.params.js';
 import { FindPersonenkontextDto } from './find-personenkontext.dto.js';
+import { Public } from 'nest-keycloak-connect';
 
 @ApiTags('person')
 @Controller({ path: 'person' })
+@Public()
 export class PersonController {
     public constructor(
         private readonly personUc: PersonUc,


### PR DESCRIPTION
# Description
Adds ```@Public()``` decorator to the controllers to prevent  401 unauthorized as a result.
Also removes unnecessary image from compose.yaml

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.