### PR TITLE
EW-692 Introducing dependency groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
@@ -8,6 +9,21 @@ updates:
       interval: 'daily'
     labels:
       - 'dependencies'
+    groups:
+      automapper:
+        patterns:
+          - '@automapper/*'
+      mikro-orm:
+        patterns:
+          - '@mikro-orm/core'
+          - '@mikro-orm/postgresql'
+          - '@mikro-orm/cli'
+      nestjs:
+        patterns:
+          - '@nestjs/core'
+          - '@nestjs/common'
+          - '@nestjs/platform-express'
+          - '@nestjs/testing'
     ignore:
       # Causes warnings during dependency resolution (at least in 3.12.x)
       - dependency-name: 'nest-commander'

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
                 "connect-redis": "^7.1.0",
                 "express": "^4.18.2",
                 "express-session": "^1.17.3",
-                "lodash": "^4.17.21",
                 "lodash-es": "^4.17.21",
                 "nest-commander": "~3.10",
                 "nest-keycloak-connect": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "connect-redis": "^7.1.0",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
-        "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
         "nest-commander": "~3.10",
         "nest-keycloak-connect": "^1.9.2",


### PR DESCRIPTION
# Description
Some packages are closely related and require each other. Introducing dependency groups for Dependabot should make the update process easier and leads to less PRs from Dependabot. On unused dependency was also removed.

## Links to Tickets or other pull requests
- <https://ticketsystem.dbildungscloud.de/browse/EW-692>


## Approval for review
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.