### PR TITLE
Spsh 580 Klassen einführen

### DIFF
--- a/charts/dbildungs-iam-server/seeding/dev/01_organisation.json
+++ b/charts/dbildungs-iam-server/seeding/dev/01_organisation.json
@@ -94,7 +94,26 @@
             "typ": "SCHULE",
             "administriertVon": 1,
             "zugehoerigZu": 1
+        },
+        {
+            "id": 10,
+            "kennung": "0703754-11a",
+            "name": "11a Geographisches Profil",
+            "namensergaenzung": "Keine",
+            "kuerzel": "A-Sieveking-11a-Geo",
+            "typ": "KLASSE",
+            "administriertVon": 3,
+            "zugehoerigZu": 3
+        },
+        {
+            "id": 11,
+            "kennung": "0702948-9a",
+            "name": "9a",
+            "namensergaenzung": "Keine",
+            "kuerzel": "C-Orff-9a",
+            "typ": "KLASSE",
+            "administriertVon": 4,
+            "zugehoerigZu": 4
         }
-
     ]
 }

--- a/charts/dbildungs-iam-server/seeding/dev/02_person.json
+++ b/charts/dbildungs-iam-server/seeding/dev/02_person.json
@@ -77,6 +77,30 @@
             "loaklisierung": null,
             "vertrauensstufe": null,
             "auskunftssperre": null
+        },
+        {
+            "id": 10,
+            "password": "test",
+            "vorname": "Sebastian",
+            "familienname": "Chueler"
+        },
+        {
+            "id": 11,
+            "password": "test",
+            "vorname": "Sofie",
+            "familienname": "Treber"
+        },
+        {
+            "id": 12,
+            "password": "test",
+            "vorname": "Walter",
+            "familienname": "Weiss"
+        },
+        {
+            "id": 13,
+            "password": "test",
+            "vorname": "Jesse",
+            "familienname": "Pinkmann"
         }
     ]
 }

--- a/charts/dbildungs-iam-server/seeding/dev/03_service-provider.json
+++ b/charts/dbildungs-iam-server/seeding/dev/03_service-provider.json
@@ -43,7 +43,7 @@
         },
         {
             "id": 4,
-            "name": "OPSH",
+            "name": "OP.SH",
             "target": "URL",
             "url": "https://opsh.lernnetz.de/",
             "kategorie": "UNTERRICHT",
@@ -102,7 +102,7 @@
         },
         {
             "id": 10,
-            "name": "Helpdesk",
+            "name": "Helpdesk kontaktieren",
             "target": "URL",
             "url": "https://www.secure-lernnetz.de/helpdesk/",
             "kategorie": "HINWEISE",

--- a/charts/dbildungs-iam-server/seeding/dev/05_personenkontext.json
+++ b/charts/dbildungs-iam-server/seeding/dev/05_personenkontext.json
@@ -42,6 +42,36 @@
             "rolleId": 2
         },
         {
+            "personId": 5,
+            "organisationId": 3,
+            "rolleId": 2
+        },
+        {
+            "personId": 10,
+            "organisationId": 3,
+            "rolleId": 1
+        },
+        {
+            "personId": 11,
+            "organisationId": 3,
+            "rolleId": 1
+        },
+        {
+            "personId": 12,
+            "organisationId": 4,
+            "rolleId": 1
+        },
+        {
+            "personId": 13,
+            "organisationId": 4,
+            "rolleId": 1
+        },
+        {
+            "personId": 5,
+            "organisationId": 10,
+            "rolleId": 2
+        },
+        {
             "personId": 10,
             "organisationId": 10,
             "rolleId": 1

--- a/charts/dbildungs-iam-server/seeding/dev/05_personenkontext.json
+++ b/charts/dbildungs-iam-server/seeding/dev/05_personenkontext.json
@@ -40,6 +40,26 @@
             "personId": 9,
             "organisationId": 9,
             "rolleId": 2
+        },
+        {
+            "personId": 10,
+            "organisationId": 10,
+            "rolleId": 1
+        },
+        {
+            "personId": 11,
+            "organisationId": 10,
+            "rolleId": 1
+        },
+        {
+            "personId": 12,
+            "organisationId": 11,
+            "rolleId": 1
+        },
+        {
+            "personId": 13,
+            "organisationId": 11,
+            "rolleId": 1
         }
     ]
 }

--- a/seeding/dev/01_organisation.json
+++ b/seeding/dev/01_organisation.json
@@ -94,7 +94,26 @@
             "typ": "SCHULE",
             "administriertVon": 1,
             "zugehoerigZu": 1
+        },
+        {
+            "id": 10,
+            "kennung": "0703754-11a",
+            "name": "11a Geographisches Profil",
+            "namensergaenzung": "Keine",
+            "kuerzel": "A-Sieveking-11a-Geo",
+            "typ": "KLASSE",
+            "administriertVon": 3,
+            "zugehoerigZu": 3
+        },
+        {
+            "id": 11,
+            "kennung": "0702948-9a",
+            "name": "9a",
+            "namensergaenzung": "Keine",
+            "kuerzel": "C-Orff-9a",
+            "typ": "KLASSE",
+            "administriertVon": 4,
+            "zugehoerigZu": 4
         }
-
     ]
 }

--- a/seeding/dev/02_person.json
+++ b/seeding/dev/02_person.json
@@ -77,6 +77,30 @@
             "loaklisierung": null,
             "vertrauensstufe": null,
             "auskunftssperre": null
+        },
+        {
+            "id": 10,
+            "password": "test",
+            "vorname": "Sebastian",
+            "familienname": "Chueler"
+        },
+        {
+            "id": 11,
+            "password": "test",
+            "vorname": "Sofie",
+            "familienname": "Treber"
+        },
+        {
+            "id": 12,
+            "password": "test",
+            "vorname": "Walter",
+            "familienname": "Weiss"
+        },
+        {
+            "id": 13,
+            "password": "test",
+            "vorname": "Jesse",
+            "familienname": "Pinkmann"
         }
     ]
 }

--- a/seeding/dev/03_service-provider.json
+++ b/seeding/dev/03_service-provider.json
@@ -43,7 +43,7 @@
         },
         {
             "id": 4,
-            "name": "OPSH",
+            "name": "OP.SH",
             "target": "URL",
             "url": "https://opsh.lernnetz.de/",
             "kategorie": "UNTERRICHT",
@@ -102,7 +102,7 @@
         },
         {
             "id": 10,
-            "name": "Helpdesk",
+            "name": "Helpdesk kontaktieren",
             "target": "URL",
             "url": "https://www.secure-lernnetz.de/helpdesk/",
             "kategorie": "HINWEISE",

--- a/seeding/dev/05_personenkontext.json
+++ b/seeding/dev/05_personenkontext.json
@@ -42,6 +42,36 @@
             "rolleId": 2
         },
         {
+            "personId": 5,
+            "organisationId": 3,
+            "rolleId": 2
+        },
+        {
+            "personId": 10,
+            "organisationId": 3,
+            "rolleId": 1
+        },
+        {
+            "personId": 11,
+            "organisationId": 3,
+            "rolleId": 1
+        },
+        {
+            "personId": 12,
+            "organisationId": 4,
+            "rolleId": 1
+        },
+        {
+            "personId": 13,
+            "organisationId": 4,
+            "rolleId": 1
+        },
+        {
+            "personId": 5,
+            "organisationId": 10,
+            "rolleId": 2
+        },
+        {
             "personId": 10,
             "organisationId": 10,
             "rolleId": 1

--- a/seeding/dev/05_personenkontext.json
+++ b/seeding/dev/05_personenkontext.json
@@ -40,6 +40,26 @@
             "personId": 9,
             "organisationId": 9,
             "rolleId": 2
+        },
+        {
+            "personId": 10,
+            "organisationId": 10,
+            "rolleId": 1
+        },
+        {
+            "personId": 11,
+            "organisationId": 10,
+            "rolleId": 1
+        },
+        {
+            "personId": 12,
+            "organisationId": 11,
+            "rolleId": 1
+        },
+        {
+            "personId": 13,
+            "organisationId": 11,
+            "rolleId": 1
         }
     ]
 }

--- a/seeding/seeding-integration-test/all/02_person.json
+++ b/seeding/seeding-integration-test/all/02_person.json
@@ -25,6 +25,11 @@
             "vertrauensstufe": null,
             "auskunftssperre": null,
             "dataProvider": "431d8433-759c-4dbe-aaab-00b9a781f467"
+        },
+        {
+            "password": "test",
+            "vorname": "Unused person without Id",
+            "familienname": "For Test purposes"
         }
     ]
 }

--- a/seeding/seeding-integration-test/personenkontextSpecificationViolated/01_organisation.json
+++ b/seeding/seeding-integration-test/personenkontextSpecificationViolated/01_organisation.json
@@ -1,0 +1,33 @@
+{
+    "entityName": "Organisation",
+    "entities": [
+        {
+            "id": 1,
+            "kennung": "Root",
+            "name": "Root",
+            "namensergaenzung": "Keine",
+            "kuerzel": "RT",
+            "typ": "TRAEGER"
+        },
+        {
+            "id": 2345,
+            "kennung": "Schule2345",
+            "name": "Schule2345",
+            "namensergaenzung": "Keine",
+            "kuerzel": "2345",
+            "typ": "SCHULE"
+        },
+        {
+            "id": 2346,
+            "kennung": "Schule2345-Klasse9a",
+            "name": "Klasse9a",
+            "namensergaenzung": "Keine",
+            "kuerzel": "2346",
+            "typ": "KLASSE",
+            "administriertVon": 2345,
+            "zugehoerigZu": 2345
+        }
+    ]
+}
+
+

--- a/seeding/seeding-integration-test/personenkontextSpecificationViolated/02_person.json
+++ b/seeding/seeding-integration-test/personenkontextSpecificationViolated/02_person.json
@@ -1,0 +1,14 @@
+{
+    "entityName": "Person",
+    "entities": [
+        {
+            "id": 2345,
+            "password": "test",
+            "vorname": "Sven",
+            "familienname": "Lehrer"
+        }
+    ]
+}
+
+
+

--- a/seeding/seeding-integration-test/personenkontextSpecificationViolated/04_rolle.json
+++ b/seeding/seeding-integration-test/personenkontextSpecificationViolated/04_rolle.json
@@ -1,0 +1,21 @@
+{
+    "entityName": "Rolle",
+    "entities": [
+        {
+            "id": 2345,
+            "name": "LehrerRolle2345",
+            "administeredBySchulstrukturknoten": 1,
+            "rollenart": "LEHR",
+            "merkmale": [],
+            "systemrechte": []
+        },
+        {
+            "id": 2346,
+            "name": "SchulAdminRolle2346",
+            "administeredBySchulstrukturknoten": 1,
+            "rollenart": "LEIT",
+            "merkmale": [],
+            "systemrechte": []
+        }
+    ]
+}

--- a/seeding/seeding-integration-test/personenkontextSpecificationViolated/05_personenkontext.json
+++ b/seeding/seeding-integration-test/personenkontextSpecificationViolated/05_personenkontext.json
@@ -1,0 +1,10 @@
+{
+    "entityName": "Personenkontext",
+    "entities": [
+        {
+            "personId": 2345,
+            "organisationId": 2346,
+            "rolleId": 2345
+        }
+    ]
+}

--- a/src/console/console.module.ts
+++ b/src/console/console.module.ts
@@ -25,7 +25,7 @@ import { ServiceProviderRepo } from '../modules/service-provider/repo/service-pr
 import { RolleModule } from '../modules/rolle/rolle.module.js';
 import { ServiceProviderModule } from '../modules/service-provider/service-provider.module.js';
 import { PersonModule } from '../modules/person/person.module.js';
-import {PersonenKontextModule} from "../modules/personenkontext/personenkontext.module.js";
+import { PersonenKontextModule } from '../modules/personenkontext/personenkontext.module.js';
 
 @Module({
     imports: [

--- a/src/console/console.module.ts
+++ b/src/console/console.module.ts
@@ -22,10 +22,10 @@ import { OrganisationModule } from '../modules/organisation/organisation.module.
 import { RolleRepo } from '../modules/rolle/repo/rolle.repo.js';
 import { RolleFactory } from '../modules/rolle/domain/rolle.factory.js';
 import { ServiceProviderRepo } from '../modules/service-provider/repo/service-provider.repo.js';
-import { DBiamPersonenkontextRepo } from '../modules/personenkontext/persistence/dbiam-personenkontext.repo.js';
 import { RolleModule } from '../modules/rolle/rolle.module.js';
 import { ServiceProviderModule } from '../modules/service-provider/service-provider.module.js';
 import { PersonModule } from '../modules/person/person.module.js';
+import {PersonenKontextModule} from "../modules/personenkontext/personenkontext.module.js";
 
 @Module({
     imports: [
@@ -35,6 +35,7 @@ import { PersonModule } from '../modules/person/person.module.js';
         PersonModule,
         RolleModule,
         ServiceProviderModule,
+        PersonenKontextModule,
         LoggerModule.register(ConsoleModule.name),
         ConfigModule.forRoot({
             isGlobal: true,
@@ -75,7 +76,6 @@ import { PersonModule } from '../modules/person/person.module.js';
         PersonRepository,
         PersonFactory,
         PersonRepository,
-        DBiamPersonenkontextRepo,
         RolleRepo,
         RolleFactory,
         ServiceProviderRepo,

--- a/src/console/dbseed/db-seed.module.ts
+++ b/src/console/dbseed/db-seed.module.ts
@@ -6,7 +6,6 @@ import { DbSeedMapper } from './db-seed-mapper.js';
 import { DbSeedConsole } from './db-seed.console.js';
 import { PersonModule } from '../../modules/person/person.module.js';
 import { PersonenKontextModule } from '../../modules/personenkontext/personenkontext.module.js';
-import { DBiamPersonenkontextRepo } from '../../modules/personenkontext/persistence/dbiam-personenkontext.repo.js';
 import { OrganisationModule } from '../../modules/organisation/organisation.module.js';
 import { RolleModule } from '../../modules/rolle/rolle.module.js';
 import { ServiceProviderModule } from '../../modules/service-provider/service-provider.module.js';
@@ -22,7 +21,7 @@ import { KeycloakAdministrationModule } from '../../modules/keycloak-administrat
         KeycloakAdministrationModule,
         LoggerModule.register(DbSeedModule.name),
     ],
-    providers: [DbSeedService, DbSeedMapper, DbSeedConsole, DBiamPersonenkontextRepo],
+    providers: [DbSeedService, DbSeedMapper, DbSeedConsole],
     exports: [DbSeedService, DbSeedMapper, DbSeedConsole],
 })
 export class DbSeedModule {}

--- a/src/console/dbseed/db-seed.service.integration-spec.ts
+++ b/src/console/dbseed/db-seed.service.integration-spec.ts
@@ -19,6 +19,9 @@ import { ServiceProviderModule } from '../../modules/service-provider/service-pr
 import { RolleModule } from '../../modules/rolle/rolle.module.js';
 import { PersonModule } from '../../modules/person/person.module.js';
 import { DbSeedModule } from './db-seed.module.js';
+import {
+    GleicheRolleAnKlasseWieSchuleError
+} from "../../modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.js";
 
 describe('DbSeedServiceIntegration', () => {
     let module: TestingModule;
@@ -104,6 +107,33 @@ describe('DbSeedServiceIntegration', () => {
                 await dbSeedService.seedOrganisation(fileContentOrganisationAsStr);
 
                 await expect(dbSeedService.seedPersonenkontext(fileContentAsStr)).rejects.toThrow(EntityNotFoundError);
+            });
+        });
+
+        describe('with violated Personenkontext Klasse specification', () => {
+            it('should throw EntityNotFoundError', async () => {
+                const fileContentAsStr: string = fs.readFileSync(
+                    `./seeding/seeding-integration-test/personenkontextSpecificationViolated/05_personenkontext.json`,
+                    'utf-8',
+                );
+                const fileContentOrganisationAsStr: string = fs.readFileSync(
+                    `./seeding/seeding-integration-test/personenkontextSpecificationViolated/01_organisation.json`,
+                    'utf-8',
+                );
+                await dbSeedService.seedOrganisation(fileContentOrganisationAsStr);
+                const fileContentRolleAsStr: string = fs.readFileSync(
+                    `./seeding/seeding-integration-test/personenkontextSpecificationViolated/04_rolle.json`,
+                    'utf-8',
+                );
+                await dbSeedService.seedRolle(fileContentRolleAsStr);
+
+                const fileContentPersonAsStr: string = fs.readFileSync(
+                    `./seeding/seeding-integration-test/personenkontextSpecificationViolated/02_person.json`,
+                    'utf-8',
+                );
+                await dbSeedService.seedPerson(fileContentPersonAsStr);
+
+                await expect(dbSeedService.seedPersonenkontext(fileContentAsStr)).rejects.toThrow(GleicheRolleAnKlasseWieSchuleError);
             });
         });
     });

--- a/src/console/dbseed/db-seed.service.integration-spec.ts
+++ b/src/console/dbseed/db-seed.service.integration-spec.ts
@@ -19,9 +19,7 @@ import { ServiceProviderModule } from '../../modules/service-provider/service-pr
 import { RolleModule } from '../../modules/rolle/rolle.module.js';
 import { PersonModule } from '../../modules/person/person.module.js';
 import { DbSeedModule } from './db-seed.module.js';
-import {
-    GleicheRolleAnKlasseWieSchuleError
-} from "../../modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.js";
+import { GleicheRolleAnKlasseWieSchuleError } from '../../modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.js';
 
 describe('DbSeedServiceIntegration', () => {
     let module: TestingModule;
@@ -133,7 +131,9 @@ describe('DbSeedServiceIntegration', () => {
                 );
                 await dbSeedService.seedPerson(fileContentPersonAsStr);
 
-                await expect(dbSeedService.seedPersonenkontext(fileContentAsStr)).rejects.toThrow(GleicheRolleAnKlasseWieSchuleError);
+                await expect(dbSeedService.seedPersonenkontext(fileContentAsStr)).rejects.toThrow(
+                    GleicheRolleAnKlasseWieSchuleError,
+                );
             });
         });
     });

--- a/src/console/dbseed/db-seed.service.spec.ts
+++ b/src/console/dbseed/db-seed.service.spec.ts
@@ -25,7 +25,7 @@ import { DBiamPersonenkontextRepo } from '../../modules/personenkontext/persiste
 import { ServiceProviderFactory } from '../../modules/service-provider/domain/service-provider.factory.js';
 import { KeycloakUserService, UserDo } from '../../modules/keycloak-administration/index.js';
 import { Person } from '../../modules/person/domain/person.js';
-import {DBiamPersonenkontextService} from "../../modules/personenkontext/domain/dbiam-personenkontext.service.js";
+import { DBiamPersonenkontextService } from '../../modules/personenkontext/domain/dbiam-personenkontext.service.js';
 
 describe('DbSeedService', () => {
     let module: TestingModule;

--- a/src/console/dbseed/db-seed.service.spec.ts
+++ b/src/console/dbseed/db-seed.service.spec.ts
@@ -25,6 +25,7 @@ import { DBiamPersonenkontextRepo } from '../../modules/personenkontext/persiste
 import { ServiceProviderFactory } from '../../modules/service-provider/domain/service-provider.factory.js';
 import { KeycloakUserService, UserDo } from '../../modules/keycloak-administration/index.js';
 import { Person } from '../../modules/person/domain/person.js';
+import {DBiamPersonenkontextService} from "../../modules/personenkontext/domain/dbiam-personenkontext.service.js";
 
 describe('DbSeedService', () => {
     let module: TestingModule;
@@ -46,6 +47,7 @@ describe('DbSeedService', () => {
                 DbSeedService,
                 RolleFactory,
                 ServiceProviderFactory,
+                DBiamPersonenkontextService,
                 {
                     provide: PersonFactory,
                     useValue: createMock<PersonFactory>(),

--- a/src/console/dbseed/db-seed.service.ts
+++ b/src/console/dbseed/db-seed.service.ts
@@ -26,6 +26,7 @@ import { ServiceProviderFactory } from '../../modules/service-provider/domain/se
 import { ServiceProviderRepo } from '../../modules/service-provider/repo/service-provider.repo.js';
 import { ServerConfig, DataConfig } from '../../shared/config/index.js';
 import { FindUserFilter, KeycloakUserService, UserDo } from '../../modules/keycloak-administration/index.js';
+import {DBiamPersonenkontextService} from "../../modules/personenkontext/domain/dbiam-personenkontext.service.js";
 
 @Injectable()
 export class DbSeedService {
@@ -42,6 +43,7 @@ export class DbSeedService {
         private readonly serviceProviderRepo: ServiceProviderRepo,
         private readonly serviceProviderFactory: ServiceProviderFactory,
         private readonly kcUserService: KeycloakUserService,
+        private readonly dbiamPersonenkontextService: DBiamPersonenkontextService,
         config: ConfigService<ServerConfig>,
     ) {
         this.ROOT_ORGANISATION_ID = config.getOrThrow<DataConfig>('DATA').ROOT_ORGANISATION_ID;
@@ -238,6 +240,13 @@ export class DbSeedService {
                 this.getReferencedOrganisation(file.organisationId).id,
                 this.getReferencedRolle(file.rolleId).id,
             );
+
+            //Check specifications
+            const specificationCheckError: Option<DomainError> = await this.dbiamPersonenkontextService.checkSpecifications(personenKontext);
+            if (specificationCheckError) {
+                throw specificationCheckError;
+            }
+
             persistedPersonenkontexte.push(await this.dBiamPersonenkontextRepo.save(personenKontext));
             //at the moment no saving of Personenkontext in a map for referencing
         }

--- a/src/console/dbseed/db-seed.service.ts
+++ b/src/console/dbseed/db-seed.service.ts
@@ -26,7 +26,7 @@ import { ServiceProviderFactory } from '../../modules/service-provider/domain/se
 import { ServiceProviderRepo } from '../../modules/service-provider/repo/service-provider.repo.js';
 import { ServerConfig, DataConfig } from '../../shared/config/index.js';
 import { FindUserFilter, KeycloakUserService, UserDo } from '../../modules/keycloak-administration/index.js';
-import {DBiamPersonenkontextService} from "../../modules/personenkontext/domain/dbiam-personenkontext.service.js";
+import { DBiamPersonenkontextService } from '../../modules/personenkontext/domain/dbiam-personenkontext.service.js';
 
 @Injectable()
 export class DbSeedService {
@@ -242,7 +242,8 @@ export class DbSeedService {
             );
 
             //Check specifications
-            const specificationCheckError: Option<DomainError> = await this.dbiamPersonenkontextService.checkSpecifications(personenKontext);
+            const specificationCheckError: Option<DomainError> =
+                await this.dbiamPersonenkontextService.checkSpecifications(personenKontext);
             if (specificationCheckError) {
                 throw specificationCheckError;
             }

--- a/src/modules/authentication/domain/person-permissions.spec.ts
+++ b/src/modules/authentication/domain/person-permissions.spec.ts
@@ -5,7 +5,7 @@ import { PersonPermissionsRepo } from './person-permission.repo.js';
 import { PersonRepository } from '../../person/persistence/person.repository.js';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Person } from '../../person/domain/person.js';
-import {PersonFields, PersonPermissions} from './person-permissions.js';
+import { PersonFields, PersonPermissions } from './person-permissions.js';
 import { DBiamPersonenkontextRepo } from '../../personenkontext/persistence/dbiam-personenkontext.repo.js';
 import { Personenkontext } from '../../personenkontext/domain/personenkontext.js';
 import { RolleID } from '../../../shared/types/index.js';
@@ -73,7 +73,7 @@ describe('PersonPermissions', () => {
 
     describe('personFields', () => {
         describe('when person can be found', () => {
-            it('should return cached person fields', async () => {
+            it('should return cached person fields', () => {
                 const person: Person<true> = createPerson();
                 const personenkontexte: Personenkontext<true>[] = [
                     Personenkontext.construct('1', faker.date.past(), faker.date.recent(), '1', '1', '1'),

--- a/src/modules/authentication/domain/person-permissions.spec.ts
+++ b/src/modules/authentication/domain/person-permissions.spec.ts
@@ -5,10 +5,24 @@ import { PersonPermissionsRepo } from './person-permission.repo.js';
 import { PersonRepository } from '../../person/persistence/person.repository.js';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Person } from '../../person/domain/person.js';
-import { PersonPermissions } from './person-permissions.js';
+import {PersonFields, PersonPermissions} from './person-permissions.js';
 import { DBiamPersonenkontextRepo } from '../../personenkontext/persistence/dbiam-personenkontext.repo.js';
 import { Personenkontext } from '../../personenkontext/domain/personenkontext.js';
 import { RolleID } from '../../../shared/types/index.js';
+
+function createPerson(): Person<true> {
+    return Person.construct(
+        faker.string.uuid(),
+        faker.date.past(),
+        faker.date.recent(),
+        faker.person.lastName(),
+        faker.person.firstName(),
+        '1',
+        faker.lorem.word(),
+        undefined,
+        faker.string.uuid(),
+    );
+}
 
 describe('PersonPermissions', () => {
     let module: TestingModule;
@@ -42,17 +56,7 @@ describe('PersonPermissions', () => {
     describe('getRoleIds', () => {
         describe('when person can be found', () => {
             it('should load PersonPermissions', async () => {
-                const person: Person<true> = Person.construct(
-                    faker.string.uuid(),
-                    faker.date.past(),
-                    faker.date.recent(),
-                    faker.person.lastName(),
-                    faker.person.firstName(),
-                    '1',
-                    faker.lorem.word(),
-                    undefined,
-                    faker.string.uuid(),
-                );
+                const person: Person<true> = createPerson();
                 const personenkontexte: Personenkontext<true>[] = [
                     Personenkontext.construct('1', faker.date.past(), faker.date.recent(), '1', '1', '1'),
                 ];
@@ -63,6 +67,28 @@ describe('PersonPermissions', () => {
                 );
                 const ids: RolleID[] = await personPermissions.getRoleIds();
                 expect(ids).toContain('1');
+            });
+        });
+    });
+
+    describe('personFields', () => {
+        describe('when person can be found', () => {
+            it('should return cached person fields', async () => {
+                const person: Person<true> = createPerson();
+                const personenkontexte: Personenkontext<true>[] = [
+                    Personenkontext.construct('1', faker.date.past(), faker.date.recent(), '1', '1', '1'),
+                ];
+                dbiamPersonenkontextRepoMock.findByPerson.mockResolvedValueOnce(personenkontexte);
+                const personPermissions: PersonPermissions = new PersonPermissions(
+                    dbiamPersonenkontextRepoMock,
+                    person,
+                );
+                const personFields: PersonFields = personPermissions.personFields;
+                expect(personFields.id).toEqual(person.id);
+                expect(personFields.familienname).toEqual(person.familienname);
+                expect(personFields.vorname).toEqual(person.vorname);
+                expect(personFields.keycloakUserId).toEqual(person.keycloakUserId);
+                expect(personFields.username).toEqual(person.username);
             });
         });
     });

--- a/src/modules/authentication/domain/person-permissions.ts
+++ b/src/modules/authentication/domain/person-permissions.ts
@@ -3,7 +3,7 @@ import { Person } from '../../person/domain/person.js';
 import { Personenkontext } from '../../personenkontext/domain/personenkontext.js';
 import { DBiamPersonenkontextRepo } from '../../personenkontext/persistence/dbiam-personenkontext.repo.js';
 
-type PersonFields = Pick<
+export type PersonFields = Pick<
     Person<true>,
     | 'id'
     | 'keycloakUserId'

--- a/src/modules/organisation/domain/organisation.enums.ts
+++ b/src/modules/organisation/domain/organisation.enums.ts
@@ -3,6 +3,7 @@ export enum OrganisationsTyp {
     LAND = 'LAND',
     TRAEGER = 'TRAEGER',
     SCHULE = 'SCHULE',
+    KLASSE = 'KLASSE',
     ANBIETER = 'ANBIETER',
     SONSTIGE = 'SONSTIGE ORGANISATION / EINRICHTUNG',
     UNBEST = 'UNBESTAETIGT',

--- a/src/modules/personenkontext/api/dbiam-personenkontext.controller.integration-spec.ts
+++ b/src/modules/personenkontext/api/dbiam-personenkontext.controller.integration-spec.ts
@@ -1,10 +1,10 @@
-import {faker} from '@faker-js/faker';
-import {MikroORM} from '@mikro-orm/core';
-import {INestApplication} from '@nestjs/common';
-import {APP_PIPE} from '@nestjs/core';
-import {Test, TestingModule} from '@nestjs/testing';
-import request, {Response} from 'supertest';
-import {App} from 'supertest/types.js';
+import { faker } from '@faker-js/faker';
+import { MikroORM } from '@mikro-orm/core';
+import { INestApplication } from '@nestjs/common';
+import { APP_PIPE } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import request, { Response } from 'supertest';
+import { App } from 'supertest/types.js';
 import {
     ConfigTestModule,
     DatabaseTestModule,
@@ -12,18 +12,18 @@ import {
     DoFactory,
     MapperTestModule,
 } from '../../../../test/utils/index.js';
-import {GlobalValidationPipe} from '../../../shared/validation/index.js';
-import {OrganisationDo} from '../../organisation/domain/organisation.do.js';
-import {OrganisationRepo} from '../../organisation/persistence/organisation.repo.js';
-import {PersonDo} from '../../person/domain/person.do.js';
-import {PersonRepo} from '../../person/persistence/person.repo.js';
-import {Rolle} from '../../rolle/domain/rolle.js';
-import {RolleRepo} from '../../rolle/repo/rolle.repo.js';
-import {Personenkontext} from '../domain/personenkontext.js';
-import {PersonenKontextApiModule} from '../personenkontext-api.module.js';
-import {DBiamPersonenkontextRepo} from '../persistence/dbiam-personenkontext.repo.js';
-import {OrganisationsTyp} from "../../organisation/domain/organisation.enums.js";
-import {RollenArt} from "../../rolle/domain/rolle.enums.js";
+import { GlobalValidationPipe } from '../../../shared/validation/index.js';
+import { OrganisationDo } from '../../organisation/domain/organisation.do.js';
+import { OrganisationRepo } from '../../organisation/persistence/organisation.repo.js';
+import { PersonDo } from '../../person/domain/person.do.js';
+import { PersonRepo } from '../../person/persistence/person.repo.js';
+import { Rolle } from '../../rolle/domain/rolle.js';
+import { RolleRepo } from '../../rolle/repo/rolle.repo.js';
+import { Personenkontext } from '../domain/personenkontext.js';
+import { PersonenKontextApiModule } from '../personenkontext-api.module.js';
+import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
+import { RollenArt } from '../../rolle/domain/rolle.enums.js';
 
 function createPersonenkontext<WasPersisted extends boolean>(
     this: void,
@@ -182,7 +182,9 @@ describe('dbiam Personenkontext API', () => {
 
             it('when rolle is not found', async () => {
                 const person: PersonDo<true> = await personRepo.save(DoFactory.createPerson(false));
-                const organisation: OrganisationDo<true> = await organisationRepo.save(DoFactory.createOrganisation(false));
+                const organisation: OrganisationDo<true> = await organisationRepo.save(
+                    DoFactory.createOrganisation(false),
+                );
                 const response: Response = await request(app.getHttpServer() as App)
                     .post('/dbiam/personenkontext')
                     .send({
@@ -195,8 +197,10 @@ describe('dbiam Personenkontext API', () => {
             });
 
             it('when rollenart of rolle is not LEHR or LERN', async () => {
-                const orgaDo: OrganisationDo<false> = DoFactory.createOrganisation(false, {typ: OrganisationsTyp.KLASSE});
-                const rolleDummy : Rolle<false> = DoFactory.createRolle(false, {rollenart: RollenArt.SYSADMIN});
+                const orgaDo: OrganisationDo<false> = DoFactory.createOrganisation(false, {
+                    typ: OrganisationsTyp.KLASSE,
+                });
+                const rolleDummy: Rolle<false> = DoFactory.createRolle(false, { rollenart: RollenArt.SYSADMIN });
 
                 const person: PersonDo<true> = await personRepo.save(DoFactory.createPerson(false));
                 const organisation: OrganisationDo<true> = await organisationRepo.save(orgaDo);
@@ -215,15 +219,20 @@ describe('dbiam Personenkontext API', () => {
             it('when rollenart for Schule and Klasse are not equal', async () => {
                 //create admin on Schule
                 const admin: PersonDo<true> = await personRepo.save(DoFactory.createPerson(false));
-                const schuleDo: OrganisationDo<false> = DoFactory.createOrganisation(false, {typ: OrganisationsTyp.SCHULE});
-                const adminRolleDummy : Rolle<false> = DoFactory.createRolle(false, {rollenart: RollenArt.ORGADMIN});
+                const schuleDo: OrganisationDo<false> = DoFactory.createOrganisation(false, {
+                    typ: OrganisationsTyp.SCHULE,
+                });
+                const adminRolleDummy: Rolle<false> = DoFactory.createRolle(false, { rollenart: RollenArt.ORGADMIN });
 
                 const schule: OrganisationDo<true> = await organisationRepo.save(schuleDo);
                 const adminRolle: Rolle<true> = await rolleRepo.save(adminRolleDummy);
                 await personenkontextRepo.save(Personenkontext.createNew(admin.id, schule.id, adminRolle.id));
 
-                const klasseDo: OrganisationDo<false> = DoFactory.createOrganisation(false, {typ: OrganisationsTyp.KLASSE, administriertVon: schule.id});
-                const lehrRolleDummy : Rolle<false> = DoFactory.createRolle(false, {rollenart: RollenArt.LEHR});
+                const klasseDo: OrganisationDo<false> = DoFactory.createOrganisation(false, {
+                    typ: OrganisationsTyp.KLASSE,
+                    administriertVon: schule.id,
+                });
+                const lehrRolleDummy: Rolle<false> = DoFactory.createRolle(false, { rollenart: RollenArt.LEHR });
                 const lehrer: PersonDo<true> = admin;
                 const klasse: OrganisationDo<true> = await organisationRepo.save(klasseDo);
                 const lehrRolle: Rolle<true> = await rolleRepo.save(lehrRolleDummy);
@@ -238,6 +247,5 @@ describe('dbiam Personenkontext API', () => {
                 expect(response.status).toBe(400);
             });
         });
-
     });
 });

--- a/src/modules/personenkontext/api/dbiam-personenkontext.controller.ts
+++ b/src/modules/personenkontext/api/dbiam-personenkontext.controller.ts
@@ -60,7 +60,9 @@ export class DBiamPersonenkontextController {
         description: 'Test',
         type: DBiamPersonenkontextResponse,
     })
-    @ApiBadRequestResponse({ description: 'The personenkontext could not be created, may due to unsatisfied specifications.' })
+    @ApiBadRequestResponse({
+        description: 'The personenkontext could not be created, may due to unsatisfied specifications.',
+    })
     @ApiUnauthorizedResponse({ description: 'Not authorized to create personenkontext.' })
     @ApiForbiddenResponse({ description: 'Insufficient permission to create personenkontext.' })
     @ApiInternalServerErrorResponse({ description: 'Internal server error while creating personenkontext.' })

--- a/src/modules/personenkontext/api/dbiam-personenkontext.controller.ts
+++ b/src/modules/personenkontext/api/dbiam-personenkontext.controller.ts
@@ -21,7 +21,7 @@ import { DBiamCreatePersonenkontextBodyParams } from './dbiam-create-personenkon
 import { DBiamFindPersonenkontexteByPersonIdParams } from './dbiam-find-personenkontext-by-personid.params.js';
 import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
 import { DBiamPersonenkontextResponse } from './dbiam-personenkontext.response.js';
-import {DBiamPersonenkontextService} from "../domain/dbiam-personenkontext.service.js";
+import { DBiamPersonenkontextService } from '../domain/dbiam-personenkontext.service.js';
 
 @UseFilters(SchulConnexValidationErrorFilter)
 @ApiTags('dbiam-personenkontexte')
@@ -104,7 +104,8 @@ export class DBiamPersonenkontextController {
         }
 
         //Check specifications
-        const specificationCheckError: Option<DomainError> = await this.dbiamPersonenkontextService.checkSpecifications(newPersonenkontext);
+        const specificationCheckError: Option<DomainError> =
+            await this.dbiamPersonenkontextService.checkSpecifications(newPersonenkontext);
         if (specificationCheckError) {
             throw SchulConnexErrorMapper.mapSchulConnexErrorToHttpException(
                 SchulConnexErrorMapper.mapDomainErrorToSchulConnexError(specificationCheckError),

--- a/src/modules/personenkontext/domain/dbiam-personenkontext.service.ts
+++ b/src/modules/personenkontext/domain/dbiam-personenkontext.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { DomainError } from '../../../shared/error/index.js';
+import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
+import { Personenkontext } from './personenkontext.js';
+import {NurLehrUndLernAnKlasse} from "../specification/nur-lehr-und-lern-an-klasse.js";
+import {GleicheRolleAnKlasseWieSchule} from "../specification/gleiche-rolle-an-klasse-wie-schule.js";
+import {PersonenkontextKlasseSpecification} from "../specification/personenkontext-klasse-specification.js";
+import {OrganisationRepo} from "../../organisation/persistence/organisation.repo.js";
+import {RolleRepo} from "../../rolle/repo/rolle.repo.js";
+
+@Injectable()
+export class DBiamPersonenkontextService {
+    public constructor(
+        private readonly personenkontextRepo: DBiamPersonenkontextRepo,
+        private readonly organisationRepo: OrganisationRepo,
+        private readonly rolleRepo: RolleRepo,
+    ) {}
+
+    public async checkSpecifications(personenkontext: Personenkontext<false>): Promise<Option<DomainError>> {
+        //Check that only teachers and students are added to classes.
+        const nurLehrUndLernAnKlasse: NurLehrUndLernAnKlasse = new NurLehrUndLernAnKlasse(
+            this.organisationRepo,
+            this.rolleRepo,
+        );
+        //Check that person has same role on parent-organisation, if organisation is a class.
+        const gleicheRolleAnKlasseWieSchule: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+            this.organisationRepo,
+            this.personenkontextRepo,
+            this.rolleRepo,
+        );
+        const pkKlasseSpecification: PersonenkontextKlasseSpecification = new PersonenkontextKlasseSpecification(
+            nurLehrUndLernAnKlasse,
+            gleicheRolleAnKlasseWieSchule,
+        );
+
+        return await pkKlasseSpecification.returnsError(personenkontext);
+    }
+}

--- a/src/modules/personenkontext/domain/dbiam-personenkontext.service.ts
+++ b/src/modules/personenkontext/domain/dbiam-personenkontext.service.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { DomainError } from '../../../shared/error/index.js';
 import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
 import { Personenkontext } from './personenkontext.js';
-import {NurLehrUndLernAnKlasse} from "../specification/nur-lehr-und-lern-an-klasse.js";
-import {GleicheRolleAnKlasseWieSchule} from "../specification/gleiche-rolle-an-klasse-wie-schule.js";
-import {PersonenkontextKlasseSpecification} from "../specification/personenkontext-klasse-specification.js";
-import {OrganisationRepo} from "../../organisation/persistence/organisation.repo.js";
-import {RolleRepo} from "../../rolle/repo/rolle.repo.js";
+import { NurLehrUndLernAnKlasse } from '../specification/nur-lehr-und-lern-an-klasse.js';
+import { GleicheRolleAnKlasseWieSchule } from '../specification/gleiche-rolle-an-klasse-wie-schule.js';
+import { PersonenkontextKlasseSpecification } from '../specification/personenkontext-klasse-specification.js';
+import { OrganisationRepo } from '../../organisation/persistence/organisation.repo.js';
+import { RolleRepo } from '../../rolle/repo/rolle.repo.js';
 
 @Injectable()
 export class DBiamPersonenkontextService {
@@ -33,6 +33,6 @@ export class DBiamPersonenkontextService {
             gleicheRolleAnKlasseWieSchule,
         );
 
-        return await pkKlasseSpecification.returnsError(personenkontext);
+        return pkKlasseSpecification.returnsError(personenkontext);
     }
 }

--- a/src/modules/personenkontext/personenkontext-api.module.ts
+++ b/src/modules/personenkontext/personenkontext-api.module.ts
@@ -12,12 +12,14 @@ import { DBiamPersonenkontextRepo } from './persistence/dbiam-personenkontext.re
 import { DBiamPersonenkontextController } from './api/dbiam-personenkontext.controller.js';
 import { DbiamPersonenkontextFilterController } from './api/dbiam-personenkontext-filter.controller.js';
 import { PersonenkontextAnlageFactory } from './domain/personenkontext-anlage.factory.js';
+import {DBiamPersonenkontextService} from "./domain/dbiam-personenkontext.service.js";
 
 @Module({
     imports: [PersonModule, RolleModule, OrganisationModule, LoggerModule.register(PersonenKontextApiModule.name)],
     providers: [
         PersonenkontextUc,
         PersonenkontextService,
+        DBiamPersonenkontextService,
         PersonenkontextRepo,
         PersonRepo,
         DBiamPersonenkontextRepo,

--- a/src/modules/personenkontext/personenkontext-api.module.ts
+++ b/src/modules/personenkontext/personenkontext-api.module.ts
@@ -12,7 +12,7 @@ import { DBiamPersonenkontextRepo } from './persistence/dbiam-personenkontext.re
 import { DBiamPersonenkontextController } from './api/dbiam-personenkontext.controller.js';
 import { DbiamPersonenkontextFilterController } from './api/dbiam-personenkontext-filter.controller.js';
 import { PersonenkontextAnlageFactory } from './domain/personenkontext-anlage.factory.js';
-import {DBiamPersonenkontextService} from "./domain/dbiam-personenkontext.service.js";
+import { DBiamPersonenkontextService } from './domain/dbiam-personenkontext.service.js';
 
 @Module({
     imports: [PersonModule, RolleModule, OrganisationModule, LoggerModule.register(PersonenKontextApiModule.name)],

--- a/src/modules/personenkontext/personenkontext.module.ts
+++ b/src/modules/personenkontext/personenkontext.module.ts
@@ -7,10 +7,11 @@ import { PersonRepo } from '../person/persistence/person.repo.js';
 import { DBiamPersonenkontextRepo } from './persistence/dbiam-personenkontext.repo.js';
 import { RolleModule } from '../rolle/rolle.module.js';
 import { OrganisationModule } from '../organisation/organisation.module.js';
+import {DBiamPersonenkontextService} from "./domain/dbiam-personenkontext.service.js";
 
 @Module({
     imports: [PersonModule, RolleModule, OrganisationModule, LoggerModule.register(PersonenKontextModule.name)],
-    providers: [PersonenkontextRepo, PersonenkontextService, PersonRepo, DBiamPersonenkontextRepo],
-    exports: [PersonenkontextService, PersonenkontextRepo, DBiamPersonenkontextRepo],
+    providers: [PersonenkontextRepo, PersonenkontextService, PersonRepo, DBiamPersonenkontextService, DBiamPersonenkontextRepo],
+    exports: [PersonenkontextService, PersonenkontextRepo, DBiamPersonenkontextService, DBiamPersonenkontextRepo],
 })
 export class PersonenKontextModule {}

--- a/src/modules/personenkontext/personenkontext.module.ts
+++ b/src/modules/personenkontext/personenkontext.module.ts
@@ -7,11 +7,17 @@ import { PersonRepo } from '../person/persistence/person.repo.js';
 import { DBiamPersonenkontextRepo } from './persistence/dbiam-personenkontext.repo.js';
 import { RolleModule } from '../rolle/rolle.module.js';
 import { OrganisationModule } from '../organisation/organisation.module.js';
-import {DBiamPersonenkontextService} from "./domain/dbiam-personenkontext.service.js";
+import { DBiamPersonenkontextService } from './domain/dbiam-personenkontext.service.js';
 
 @Module({
     imports: [PersonModule, RolleModule, OrganisationModule, LoggerModule.register(PersonenKontextModule.name)],
-    providers: [PersonenkontextRepo, PersonenkontextService, PersonRepo, DBiamPersonenkontextService, DBiamPersonenkontextRepo],
+    providers: [
+        PersonenkontextRepo,
+        PersonenkontextService,
+        PersonRepo,
+        DBiamPersonenkontextService,
+        DBiamPersonenkontextRepo,
+    ],
     exports: [PersonenkontextService, PersonenkontextRepo, DBiamPersonenkontextService, DBiamPersonenkontextRepo],
 })
 export class PersonenKontextModule {}

--- a/src/modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.spec.ts
+++ b/src/modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.spec.ts
@@ -1,0 +1,15 @@
+import { GleicheRolleAnKlasseWieSchuleError } from './gleiche-rolle-an-klasse-wie-schule.error.js';
+
+describe('GleicheRolleAnKlasseWieSchuleError', () => {
+    describe('constructor', () => {
+        describe('when calling the constructor', () => {
+            it('should set message and code', () => {
+                const error: GleicheRolleAnKlasseWieSchuleError = new GleicheRolleAnKlasseWieSchuleError({});
+                expect(error.message).toBe(
+                    'Personenkontext could not be created because it violates GleicheRolleAnKlasseWieSchule specification',
+                );
+                expect(error.code).toBe('ENTITY_COULD_NOT_BE_CREATED');
+            });
+        });
+    });
+});

--- a/src/modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.ts
+++ b/src/modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.ts
@@ -1,0 +1,11 @@
+import { DomainError } from '../../../../shared/error/index.js';
+
+export class GleicheRolleAnKlasseWieSchuleError extends DomainError {
+    public constructor(details?: unknown[] | Record<string, undefined>) {
+        super(
+            `Personenkontext could not be created because it violates GleicheRolleAnKlasseWieSchule specification`,
+            'ENTITY_COULD_NOT_BE_CREATED',
+            details,
+        );
+    }
+}

--- a/src/modules/personenkontext/specification/error/nur-lehr-und-lern-an-klasse.error.spec.ts
+++ b/src/modules/personenkontext/specification/error/nur-lehr-und-lern-an-klasse.error.spec.ts
@@ -1,0 +1,15 @@
+import { NurLehrUndLernAnKlasseError } from './nur-lehr-und-lern-an-klasse.error.js';
+
+describe('NurLehrUndLernAnKlasseError', () => {
+    describe('constructor', () => {
+        describe('when calling the constructor', () => {
+            it('should set message and code', () => {
+                const error: NurLehrUndLernAnKlasseError = new NurLehrUndLernAnKlasseError({});
+                expect(error.message).toBe(
+                    'Personenkontext could not be created because it violates NurLehrUndLernAnKlasse specification',
+                );
+                expect(error.code).toBe('ENTITY_COULD_NOT_BE_CREATED');
+            });
+        });
+    });
+});

--- a/src/modules/personenkontext/specification/error/nur-lehr-und-lern-an-klasse.error.ts
+++ b/src/modules/personenkontext/specification/error/nur-lehr-und-lern-an-klasse.error.ts
@@ -1,0 +1,11 @@
+import { DomainError } from '../../../../shared/error/index.js';
+
+export class NurLehrUndLernAnKlasseError extends DomainError {
+    public constructor(details?: unknown[] | Record<string, undefined>) {
+        super(
+            `Personenkontext could not be created because it violates NurLehrUndLernAnKlasse specification`,
+            'ENTITY_COULD_NOT_BE_CREATED',
+            details,
+        );
+    }
+}

--- a/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
+++ b/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
@@ -19,11 +19,12 @@ export class GleicheRolleAnKlasseWieSchule extends CompositeSpecification<Person
     // eslint-disable-next-line @typescript-eslint/require-await
     public async isSatisfiedBy(p: Personenkontext<boolean>): Promise<boolean> {
         const organisation: Option<OrganisationDo<true>> = await this.organisationRepo.findById(p.organisationId);
-        if (!organisation || !organisation.administriertVon) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        if (!organisation) return false;
         if (organisation.typ !== OrganisationsTyp.KLASSE) return true;
+        if (!organisation.administriertVon) return false; // Klasse always has to be administered by Schule
 
         const rolle: Option<Rolle<true>> = await this.rolleRepo.findById(p.rolleId);
-        if (!rolle) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        if (!rolle) return false;
 
         const schule: Option<OrganisationDo<true>> = await this.organisationRepo.findById(
             organisation.administriertVon,
@@ -35,7 +36,7 @@ export class GleicheRolleAnKlasseWieSchule extends CompositeSpecification<Person
         for (const pk of personenKontexte) {
             if (pk.organisationId === schule.id) {
                 const rolleAnSchule: Option<Rolle<true>> = await this.rolleRepo.findById(pk.rolleId);
-                if (!rolleAnSchule) return false; //this may also be handled via Error, but Error is not valid return-type yet
+                if (!rolleAnSchule) return false;
                 if (rolleAnSchule.rollenart === rolle.rollenart) {
                     return true;
                 }

--- a/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
+++ b/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
@@ -1,0 +1,46 @@
+import { CompositeSpecification } from '../../specification/specifications.js';
+import { Personenkontext } from '../domain/personenkontext.js';
+import { OrganisationRepo } from '../../organisation/persistence/organisation.repo.js';
+import { OrganisationDo } from '../../organisation/domain/organisation.do.js';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
+import { RolleRepo } from '../../rolle/repo/rolle.repo.js';
+import { Rolle } from '../../rolle/domain/rolle.js';
+import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
+
+export class GleicheRolleAnKlasseWieSchule extends CompositeSpecification<Personenkontext<boolean>> {
+    public constructor(
+        private readonly organisationRepo: OrganisationRepo,
+        private readonly dBiamPersonenkontextRepo: DBiamPersonenkontextRepo,
+        private readonly rolleRepo: RolleRepo,
+    ) {
+        super();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async isSatisfiedBy(p: Personenkontext<boolean>): Promise<boolean> {
+        const organisation: Option<OrganisationDo<true>> = await this.organisationRepo.findById(p.organisationId);
+        if (!organisation || !organisation.administriertVon) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        if (organisation.typ !== OrganisationsTyp.KLASSE) return true;
+
+        const rolle: Option<Rolle<true>> = await this.rolleRepo.findById(p.rolleId);
+        if (!rolle) return false; //this may also be handled via Error, but Error is not valid return-type yet
+
+        const schule: Option<OrganisationDo<true>> = await this.organisationRepo.findById(
+            organisation.administriertVon,
+        );
+        if (!schule) return false;
+
+        const personenKontexte: Personenkontext<true>[] = await this.dBiamPersonenkontextRepo.findByPerson(p.personId);
+
+        for (const pk of personenKontexte) {
+            if (pk.organisationId === schule.id) {
+                const rolleAnSchule: Option<Rolle<true>> = await this.rolleRepo.findById(pk.rolleId);
+                if (!rolleAnSchule) return false; //this may also be handled via Error, but Error is not valid return-type yet
+                if (rolleAnSchule.rollenart === rolle.rollenart) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
+++ b/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
@@ -34,11 +34,13 @@ export class GleicheRolleAnKlasseWieSchule extends CompositeSpecification<Person
         if (!schule) return false;
 
         const personenKontexte: Personenkontext<true>[] = await this.dBiamPersonenkontextRepo.findByPerson(p.personId);
-        const matchingKontext = personenKontexte.find(pk => pk.organisationId === schule.id);
+        const matchingKontext: Personenkontext<true> | undefined = personenKontexte.find(
+            (pk: Personenkontext<true>) => pk.organisationId === schule.id,
+        );
         if (!matchingKontext) return false;
         const rolleAnSchule: Option<Rolle<true>> = await this.rolleRepo.findById(matchingKontext.rolleId);
         if (!rolleAnSchule) return false;
-        
+
         return rolleAnSchule.id === p.rolleId;
     }
 }

--- a/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
+++ b/src/modules/personenkontext/specification/gleiche-rolle-an-klasse-wie-schule.ts
@@ -34,17 +34,11 @@ export class GleicheRolleAnKlasseWieSchule extends CompositeSpecification<Person
         if (!schule) return false;
 
         const personenKontexte: Personenkontext<true>[] = await this.dBiamPersonenkontextRepo.findByPerson(p.personId);
-
-        for (const pk of personenKontexte) {
-            if (pk.organisationId === schule.id) {
-                const rolleAnSchule: Option<Rolle<true>> = await this.rolleRepo.findById(pk.rolleId);
-                if (!rolleAnSchule) return false;
-                if (rolleAnSchule.id === p.rolleId) {
-                    return true; //satisfied when person already has same rolle on schule
-                }
-            }
-        }
-
-        return false;
+        const matchingKontext = personenKontexte.find(pk => pk.organisationId === schule.id);
+        if (!matchingKontext) return false;
+        const rolleAnSchule: Option<Rolle<true>> = await this.rolleRepo.findById(matchingKontext.rolleId);
+        if (!rolleAnSchule) return false;
+        
+        return rolleAnSchule.id === p.rolleId;
     }
 }

--- a/src/modules/personenkontext/specification/nur-lehr-und-lern-an-klasse.ts
+++ b/src/modules/personenkontext/specification/nur-lehr-und-lern-an-klasse.ts
@@ -8,7 +8,7 @@ import { Rolle } from '../../rolle/domain/rolle.js';
 import { RollenArt } from '../../rolle/domain/rolle.enums.js';
 
 /**
- * 'Only needs to be checked when referenced organisation is of type KLASSE'
+ * Only needs to be checked when referenced organisation is of type KLASSE.
  */
 export class NurLehrUndLernAnKlasse extends CompositeSpecification<Personenkontext<boolean>> {
     public constructor(

--- a/src/modules/personenkontext/specification/nur-lehr-und-lern-an-klasse.ts
+++ b/src/modules/personenkontext/specification/nur-lehr-und-lern-an-klasse.ts
@@ -21,11 +21,11 @@ export class NurLehrUndLernAnKlasse extends CompositeSpecification<Personenkonte
     // eslint-disable-next-line @typescript-eslint/require-await
     public async isSatisfiedBy(p: Personenkontext<boolean>): Promise<boolean> {
         const organisation: Option<OrganisationDo<true>> = await this.organisationRepo.findById(p.organisationId);
-        if (!organisation) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        if (!organisation) return false;
         if (organisation.typ !== OrganisationsTyp.KLASSE) return true;
 
         const rolle: Option<Rolle<true>> = await this.rolleRepo.findById(p.rolleId);
-        if (!rolle) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        if (!rolle) return false;
         return rolle.rollenart === RollenArt.LEHR || rolle.rollenart === RollenArt.LERN;
     }
 }

--- a/src/modules/personenkontext/specification/nur-lehr-und-lern-an-klasse.ts
+++ b/src/modules/personenkontext/specification/nur-lehr-und-lern-an-klasse.ts
@@ -1,0 +1,31 @@
+import { CompositeSpecification } from '../../specification/specifications.js';
+import { Personenkontext } from '../domain/personenkontext.js';
+import { OrganisationRepo } from '../../organisation/persistence/organisation.repo.js';
+import { OrganisationDo } from '../../organisation/domain/organisation.do.js';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
+import { RolleRepo } from '../../rolle/repo/rolle.repo.js';
+import { Rolle } from '../../rolle/domain/rolle.js';
+import { RollenArt } from '../../rolle/domain/rolle.enums.js';
+
+/**
+ * 'Only needs to be checked when referenced organisation is of type KLASSE'
+ */
+export class NurLehrUndLernAnKlasse extends CompositeSpecification<Personenkontext<boolean>> {
+    public constructor(
+        private readonly organisationRepo: OrganisationRepo,
+        private readonly rolleRepo: RolleRepo,
+    ) {
+        super();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async isSatisfiedBy(p: Personenkontext<boolean>): Promise<boolean> {
+        const organisation: Option<OrganisationDo<true>> = await this.organisationRepo.findById(p.organisationId);
+        if (!organisation) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        if (organisation.typ !== OrganisationsTyp.KLASSE) return true;
+
+        const rolle: Option<Rolle<true>> = await this.rolleRepo.findById(p.rolleId);
+        if (!rolle) return false; //this may also be handled via Error, but Error is not valid return-type yet
+        return rolle.rollenart === RollenArt.LEHR || rolle.rollenart === RollenArt.LERN;
+    }
+}

--- a/src/modules/personenkontext/specification/personenkontext-klasse-specification.ts
+++ b/src/modules/personenkontext/specification/personenkontext-klasse-specification.ts
@@ -1,0 +1,27 @@
+import { Personenkontext } from '../domain/personenkontext.js';
+import { NurLehrUndLernAnKlasse } from './nur-lehr-und-lern-an-klasse.js';
+import { GleicheRolleAnKlasseWieSchule } from './gleiche-rolle-an-klasse-wie-schule.js';
+import { DomainError } from '../../../shared/error/index.js';
+import { NurLehrUndLernAnKlasseError } from './error/nur-lehr-und-lern-an-klasse.error.js';
+import { GleicheRolleAnKlasseWieSchuleError } from './error/gleiche-rolle-an-klasse-wie-schule.error.js';
+
+/**
+ * 'This specification is not extending CompositeSpecification, but combines specifications for Personenkontexte
+ * referencing Klassen and returns dedicated errors instead of simply true or false.'
+ */
+export class PersonenkontextKlasseSpecification {
+    public constructor(
+        protected readonly nurLehrUndLernAnKlasse: NurLehrUndLernAnKlasse,
+        protected readonly gleicheRolleAnKlasseWieSchule: GleicheRolleAnKlasseWieSchule,
+    ) {}
+
+    public async returnsError(p: Personenkontext<boolean>): Promise<Option<DomainError>> {
+        if (!(await this.nurLehrUndLernAnKlasse.isSatisfiedBy(p))) {
+            return new NurLehrUndLernAnKlasseError();
+        }
+        if (!(await this.gleicheRolleAnKlasseWieSchule.isSatisfiedBy(p))) {
+            return new GleicheRolleAnKlasseWieSchuleError();
+        }
+        return undefined;
+    }
+}

--- a/src/modules/personenkontext/specification/personenkontext-specifications-mocked-repos.spec.ts
+++ b/src/modules/personenkontext/specification/personenkontext-specifications-mocked-repos.spec.ts
@@ -1,0 +1,198 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { OrganisationRepo } from '../../organisation/persistence/organisation.repo.js';
+import { ConfigTestModule, DatabaseTestModule, MapperTestModule } from '../../../../test/utils/index.js';
+import { RolleRepo } from '../../rolle/repo/rolle.repo.js';
+import { NurLehrUndLernAnKlasse } from './nur-lehr-und-lern-an-klasse.js';
+import { Personenkontext } from '../domain/personenkontext.js';
+import { faker } from '@faker-js/faker';
+import { OrganisationDo } from '../../organisation/domain/organisation.do.js';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
+import { GleicheRolleAnKlasseWieSchule } from './gleiche-rolle-an-klasse-wie-schule.js';
+import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
+import { Rolle } from '../../rolle/domain/rolle.js';
+
+function createPersonenkontext<WasPersisted extends boolean>(
+    this: void,
+    withId: WasPersisted,
+    params: Partial<Personenkontext<boolean>> = {},
+): Personenkontext<WasPersisted> {
+    const personenkontext: Personenkontext<WasPersisted> = Personenkontext.construct<boolean>(
+        withId ? faker.string.uuid() : undefined,
+        withId ? faker.date.past() : undefined,
+        withId ? faker.date.recent() : undefined,
+        faker.string.uuid(),
+        faker.string.uuid(),
+        faker.string.uuid(),
+    );
+
+    Object.assign(personenkontext, params);
+
+    return personenkontext;
+}
+
+describe('PersonenkontextSpecificationsMockedReposTest', () => {
+    let module: TestingModule;
+    let organisationRepoMock: DeepMocked<OrganisationRepo>;
+    let rolleRepoMock: DeepMocked<RolleRepo>;
+    let personenkontextRepoMock: DeepMocked<DBiamPersonenkontextRepo>;
+
+    beforeAll(async () => {
+        module = await Test.createTestingModule({
+            imports: [ConfigTestModule, DatabaseTestModule.forRoot({ isDatabaseRequired: false }), MapperTestModule],
+            providers: [
+                {
+                    provide: OrganisationRepo,
+                    useValue: createMock<OrganisationRepo>(),
+                },
+                {
+                    provide: RolleRepo,
+                    useValue: createMock<RolleRepo>(),
+                },
+                {
+                    provide: DBiamPersonenkontextRepo,
+                    useValue: createMock<DBiamPersonenkontextRepo>(),
+                },
+            ],
+        }).compile();
+        organisationRepoMock = module.get(OrganisationRepo);
+        rolleRepoMock = module.get(RolleRepo);
+        personenkontextRepoMock = module.get(DBiamPersonenkontextRepo);
+    }, 100000);
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    afterAll(async () => {
+        await module.close();
+    });
+
+    it('should be defined', () => {
+        expect(module).toBeDefined();
+    });
+
+    describe('Nur LEHR Und LERN An Klasse', () => {
+        it('should be satisfied when organisation typ is not KLASSE', async () => {
+            const organisation: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            organisation.typ = OrganisationsTyp.SCHULE;
+            const specification: NurLehrUndLernAnKlasse = new NurLehrUndLernAnKlasse(
+                organisationRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+            organisationRepoMock.findById.mockResolvedValueOnce(organisation);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeTruthy();
+        });
+
+        it('should not be satisfied when organisation could not be found', async () => {
+            const specification: NurLehrUndLernAnKlasse = new NurLehrUndLernAnKlasse(
+                organisationRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+            organisationRepoMock.findById.mockResolvedValueOnce(undefined);
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+
+        it('should not be satisfied when rolle could not be found', async () => {
+            const organisation: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            organisation.typ = OrganisationsTyp.KLASSE;
+            const specification: NurLehrUndLernAnKlasse = new NurLehrUndLernAnKlasse(
+                organisationRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+
+            organisationRepoMock.findById.mockResolvedValueOnce(organisation);
+            rolleRepoMock.findById.mockResolvedValueOnce(undefined);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+    });
+
+    describe('Gleiche Rolle An Klasse Wie Schule', () => {
+        it('should be satisfied when organisation type is not KLASSE', async () => {
+            const organisation: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            organisation.typ = OrganisationsTyp.SCHULE;
+            const specification: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+                organisationRepoMock,
+                personenkontextRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+            organisationRepoMock.findById.mockResolvedValueOnce(organisation);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeTruthy();
+        });
+
+        it('should not be satisfied when organisation could not be found', async () => {
+            const specification: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+                organisationRepoMock,
+                personenkontextRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+            organisationRepoMock.findById.mockResolvedValueOnce(undefined);
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+
+        it('should not be satisfied when organisation type is KLASSE but not administriertVon', async () => {
+            const organisation: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            organisation.typ = OrganisationsTyp.KLASSE;
+            organisation.administriertVon = undefined;
+            const specification: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+                organisationRepoMock,
+                personenkontextRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+            organisationRepoMock.findById.mockResolvedValueOnce(organisation);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+
+        it('should not be satisfied when rolle could not be found', async () => {
+            const klasse: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            klasse.typ = OrganisationsTyp.KLASSE;
+            const schule: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            schule.typ = OrganisationsTyp.SCHULE;
+            klasse.administriertVon = schule.id;
+            const specification: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+                organisationRepoMock,
+                personenkontextRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+            const foundPersonenkontext: Personenkontext<true> = createMock<Personenkontext<true>>();
+            schule.id = foundPersonenkontext.organisationId;
+            const foundPersonenkontexte: Personenkontext<true>[] = [foundPersonenkontext];
+
+            organisationRepoMock.findById.mockResolvedValueOnce(klasse); //mock Klasse
+            organisationRepoMock.findById.mockResolvedValueOnce(schule); //mock Schule
+
+            personenkontextRepoMock.findByPerson.mockResolvedValueOnce(foundPersonenkontexte);
+            rolleRepoMock.findById.mockResolvedValueOnce(undefined);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+
+        it('should not be satisfied when rolle objects are not identical', async () => {
+            const organisation: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            organisation.typ = OrganisationsTyp.KLASSE;
+            const rolle: Rolle<true> = createMock<Rolle<true>>();
+            const specification: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+                organisationRepoMock,
+                personenkontextRepoMock,
+                rolleRepoMock,
+            );
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false);
+
+            organisationRepoMock.findById.mockResolvedValueOnce(organisation);
+            rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+    });
+});

--- a/src/modules/personenkontext/specification/personenkontext-specifications.spec.ts
+++ b/src/modules/personenkontext/specification/personenkontext-specifications.spec.ts
@@ -88,10 +88,10 @@ describe('PersonenkontextSpecificationsTest', () => {
                 rolleRepoMock,
             );
             const personId: string = faker.string.uuid();
-            const personenkontext: Personenkontext<false> = createPersonenkontext(false, {personId: personId});
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false, { personId: personId });
             const foundPersonenkontextDummy: Personenkontext<false> = createPersonenkontext(false, {
                 organisationId: schule.id,
-                personId: personId
+                personId: personId,
             });
             await personenkontextRepo.save(foundPersonenkontextDummy);
 

--- a/src/modules/personenkontext/specification/personenkontext-specifications.spec.ts
+++ b/src/modules/personenkontext/specification/personenkontext-specifications.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrganisationRepo } from '../../organisation/persistence/organisation.repo.js';
+import { ConfigTestModule, DatabaseTestModule, MapperTestModule } from '../../../../test/utils/index.js';
+import { RolleRepo } from '../../rolle/repo/rolle.repo.js';
+import { Personenkontext } from '../domain/personenkontext.js';
+import { OrganisationDo } from '../../organisation/domain/organisation.do.js';
+import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
+import { GleicheRolleAnKlasseWieSchule } from './gleiche-rolle-an-klasse-wie-schule.js';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
+import { faker } from '@faker-js/faker';
+import { MikroORM } from '@mikro-orm/core';
+
+function createPersonenkontext<WasPersisted extends boolean>(
+    this: void,
+    withId: WasPersisted,
+    params: Partial<Personenkontext<boolean>> = {},
+): Personenkontext<WasPersisted> {
+    const personenkontext: Personenkontext<WasPersisted> = Personenkontext.construct<boolean>(
+        withId ? faker.string.uuid() : undefined,
+        withId ? faker.date.past() : undefined,
+        withId ? faker.date.recent() : undefined,
+        faker.string.uuid(),
+        faker.string.uuid(),
+        faker.string.uuid(),
+    );
+
+    Object.assign(personenkontext, params);
+
+    return personenkontext;
+}
+
+describe('PersonenkontextSpecificationsTest', () => {
+    let module: TestingModule;
+    let orm: MikroORM;
+    let organisationRepoMock: DeepMocked<OrganisationRepo>;
+    let rolleRepoMock: DeepMocked<RolleRepo>;
+    let personenkontextRepo: DBiamPersonenkontextRepo;
+
+    beforeAll(async () => {
+        module = await Test.createTestingModule({
+            imports: [ConfigTestModule, DatabaseTestModule.forRoot({ isDatabaseRequired: true }), MapperTestModule],
+            providers: [
+                DBiamPersonenkontextRepo,
+                {
+                    provide: OrganisationRepo,
+                    useValue: createMock<OrganisationRepo>(),
+                },
+                {
+                    provide: RolleRepo,
+                    useValue: createMock<RolleRepo>(),
+                },
+            ],
+        }).compile();
+        organisationRepoMock = module.get(OrganisationRepo);
+        rolleRepoMock = module.get(RolleRepo);
+        personenkontextRepo = module.get(DBiamPersonenkontextRepo);
+        orm = module.get(MikroORM);
+
+        await DatabaseTestModule.setupDatabase(orm);
+    }, 100000);
+
+    beforeEach(async () => {
+        jest.resetAllMocks();
+        await DatabaseTestModule.clearDatabase(orm);
+    });
+
+    afterAll(async () => {
+        await orm.close();
+        await module.close();
+    });
+
+    it('should be defined', () => {
+        expect(module).toBeDefined();
+    });
+
+    describe('Gleiche Rolle An Klasse Wie Schule', () => {
+        it('should not be satisfied when rolle could not be found', async () => {
+            const klasse: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            klasse.typ = OrganisationsTyp.KLASSE;
+            const schule: OrganisationDo<true> = createMock<OrganisationDo<true>>();
+            schule.typ = OrganisationsTyp.SCHULE;
+            schule.id = faker.string.uuid();
+            klasse.administriertVon = schule.id;
+            const specification: GleicheRolleAnKlasseWieSchule = new GleicheRolleAnKlasseWieSchule(
+                organisationRepoMock,
+                personenkontextRepo,
+                rolleRepoMock,
+            );
+            const personId: string = faker.string.uuid();
+            const personenkontext: Personenkontext<false> = createPersonenkontext(false, {personId: personId});
+            const foundPersonenkontextDummy: Personenkontext<false> = createPersonenkontext(false, {
+                organisationId: schule.id,
+                personId: personId
+            });
+            await personenkontextRepo.save(foundPersonenkontextDummy);
+
+            organisationRepoMock.findById.mockResolvedValueOnce(klasse); //mock Klasse
+            organisationRepoMock.findById.mockResolvedValueOnce(schule); //mock Schule
+
+            rolleRepoMock.findById.mockResolvedValueOnce(undefined);
+
+            expect(await specification.isSatisfiedBy(personenkontext)).toBeFalsy();
+        });
+    });
+});

--- a/src/shared/error/schul-connex-error.mapper.ts
+++ b/src/shared/error/schul-connex-error.mapper.ts
@@ -19,6 +19,8 @@ import { InvalidCharacterSetError } from './invalid-character-set.error.js';
 import { InvalidAttributeLengthError } from './invalid-attribute-length.error.js';
 import { InvalidNameError } from './invalid-name.error.js';
 import { KennungRequiredForSchuleError } from '../../modules/organisation/specification/error/kennung-required-for-schule.error.js';
+import { NurLehrUndLernAnKlasseError } from '../../modules/personenkontext/specification/error/nur-lehr-und-lern-an-klasse.error.js';
+import { GleicheRolleAnKlasseWieSchuleError } from '../../modules/personenkontext/specification/error/gleiche-rolle-an-klasse-wie-schule.error.js';
 
 export class SchulConnexErrorMapper {
     private static SCHULCONNEX_ERROR_MAPPINGS: Map<string, SchulConnexError> = new Map([
@@ -184,6 +186,25 @@ export class SchulConnexErrorMapper {
                 subcode: '00',
                 titel: 'Fehlerhafte Anfrage',
                 beschreibung: 'Die Anfrage ist fehlerhaft: Es konnte kein Benutzername generiert werden',
+            }),
+        ],
+        [
+            NurLehrUndLernAnKlasseError.name,
+            new SchulConnexError({
+                code: 400,
+                subcode: '00',
+                titel: 'Spezifikation von Personenkontext nicht erfüllt',
+                beschreibung: 'Nur Lehrer und Lernende können Klassen zugeordnet werden.',
+            }),
+        ],
+        [
+            GleicheRolleAnKlasseWieSchuleError.name,
+            new SchulConnexError({
+                code: 400,
+                subcode: '00',
+                titel: 'Spezifikation von Personenkontext nicht erfüllt',
+                beschreibung:
+                    'Die Rollenart der Person muss für die Klasse dieselbe sein wie an der zugehörigen Schule',
             }),
         ],
     ]);

--- a/src/shared/error/schul-connex-error.mapper.ts
+++ b/src/shared/error/schul-connex-error.mapper.ts
@@ -204,7 +204,7 @@ export class SchulConnexErrorMapper {
                 subcode: '00',
                 titel: 'Spezifikation von Personenkontext nicht erfüllt',
                 beschreibung:
-                    'Die Rollenart der Person muss für die Klasse dieselbe sein wie an der zugehörigen Schule',
+                    'Die Rollenart der Person muss für die Klasse dieselbe sein wie an der zugehörigen Schule.',
             }),
         ],
     ]);


### PR DESCRIPTION
# Description
- Adds checks for Personenkontexte when affected organisations are of type KLASSE.
Specifications were created to ensure, that only Personenkontexte with Rolle and Rollenart LEHR or LERN can be created, if organisation is of type KLASSE and that the person has the identical Rolle on the parent (SCHULE) organisation.

- Check is executed when creating Personenkontext via API and in the Seeding process.

- New seeding data is added: Two classes, two students per class and one class already has a teacher.

## Links to Tickets or other pull requests
Base links to copy
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-580

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.