### PR TITLE
SPSH-655: Fehlende Einschränkung der Knotenauswahl bei Create Personenkontext

### DIFF
--- a/src/modules/personenkontext/domain/personenkontext-anlage.spec.ts
+++ b/src/modules/personenkontext/domain/personenkontext-anlage.spec.ts
@@ -286,6 +286,26 @@ describe('PersonenkontextAnlage', () => {
                 expect(result).toContainEqual(organisationDo);
             });
 
+            it('should return one element, because orga as ROOT does match RollenArt SYSADMIN', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.SYSADMIN });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.ROOT,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
             it('should return empty list, because orga as LAND does not match RollenArt LEIT', async () => {
                 const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEIT });
                 const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {

--- a/src/modules/personenkontext/domain/personenkontext-anlage.spec.ts
+++ b/src/modules/personenkontext/domain/personenkontext-anlage.spec.ts
@@ -12,6 +12,8 @@ import { PersonenkontextAnlageError } from '../../../shared/error/personenkontex
 import { EntityNotFoundError } from '../../../shared/error/index.js';
 import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
 import { PersonenkontextAnlageFactory } from './personenkontext-anlage.factory.js';
+import { RollenArt } from '../../rolle/domain/rolle.enums.js';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
 
 function createPersonenkontext<WasPersisted extends boolean>(
     this: void,
@@ -35,10 +37,16 @@ function createPersonenkontext<WasPersisted extends boolean>(
 function createRolleOrganisationsPersonKontext(
     anlage: PersonenkontextAnlage,
 ): [Rolle<true>, OrganisationDo<true>, OrganisationDo<true>, OrganisationDo<true>, Personenkontext<true>] {
-    const rolle: Rolle<true> = DoFactory.createRolle(true);
-    const parentOrganisation: OrganisationDo<true> = DoFactory.createOrganisation(true);
-    const childOrganisation: OrganisationDo<true> = DoFactory.createOrganisation(true);
-    const childsChildOrganisation: OrganisationDo<true> = DoFactory.createOrganisation(true);
+    const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEHR });
+    const parentOrganisation: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+        typ: OrganisationsTyp.TRAEGER,
+    });
+    const childOrganisation: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+        typ: OrganisationsTyp.SCHULE,
+    });
+    const childsChildOrganisation: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+        typ: OrganisationsTyp.KLASSE,
+    });
     childsChildOrganisation.administriertVon = childOrganisation.id;
     childOrganisation.administriertVon = parentOrganisation.id;
     anlage.organisationId = childOrganisation.id;
@@ -149,7 +157,7 @@ describe('PersonenkontextAnlage', () => {
                 expect(result).toHaveLength(1);
             });
 
-            it('should return list of schulstrukturknoten when child of child-organisation is matching', async () => {
+            it('should return list of schulstrukturknoten when child of child-organisation is matching with two results', async () => {
                 const [rolle, parent, child, childOfChild]: [
                     Rolle<true>,
                     OrganisationDo<true>,
@@ -236,6 +244,204 @@ describe('PersonenkontextAnlage', () => {
 
             const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(rolle.id, 'nonexistent', LIMIT);
             expect(result).toHaveLength(0);
+        });
+
+        describe('filter organisations by RollenArt', () => {
+            it('should return empty list, because orga as SCHULE does not match RollenArt SYSADMIN', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.SYSADMIN });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.SCHULE,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(0);
+            });
+
+            it('should return one element, because orga as LAND does match RollenArt SYSADMIN', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.SYSADMIN });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.LAND,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
+            it('should return empty list, because orga as LAND does not match RollenArt LEIT', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEIT });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.LAND,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(0);
+            });
+
+            it('should return one element, because orga as SCHULE does match RollenArt LEIT', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEIT });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.SCHULE,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
+            it('should return one element, because orga as SCHULE does match RollenArt LERN', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LERN });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.SCHULE,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
+            it('should return one element, because orga as KLASSE does match RollenArt LERN', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LERN });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.KLASSE,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
+            it('should return empty list, because orga as LAND does not match RollenArt LERN', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LERN });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.LAND,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(0);
+            });
+
+            it('should return one element, because orga as SCHULE does match RollenArt LEHR', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEHR });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.SCHULE,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
+            it('should return one element, because orga as KLASSE does match RollenArt LEHR', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEHR });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.KLASSE,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(1);
+                expect(result).toContainEqual(organisationDo);
+            });
+
+            it('should return empty list, because orga as LAND does not match RollenArt LEHR', async () => {
+                const rolle: Rolle<true> = DoFactory.createRolle(true, { rollenart: RollenArt.LEHR });
+                const organisationDo: OrganisationDo<true> = DoFactory.createOrganisation(true, {
+                    typ: OrganisationsTyp.LAND,
+                });
+
+                organisationRepoMock.findByNameOrKennung.mockResolvedValue([organisationDo]);
+                rolleRepoMock.findById.mockResolvedValueOnce(rolle);
+                organisationRepoMock.findById.mockResolvedValue(organisationDo); //mock call to find parent in findSchulstrukturknoten
+                organisationRepoMock.findChildOrgasForIds.mockResolvedValueOnce([organisationDo]);
+
+                const result: OrganisationDo<true>[] = await anlage.findSchulstrukturknoten(
+                    rolle.id,
+                    organisationDo.name!,
+                    LIMIT,
+                );
+                expect(result).toHaveLength(0);
+            });
         });
     });
 

--- a/src/modules/personenkontext/domain/personenkontext-anlage.ts
+++ b/src/modules/personenkontext/domain/personenkontext-anlage.ts
@@ -6,6 +6,8 @@ import { OrganisationRepo } from '../../organisation/persistence/organisation.re
 import { PersonenkontextAnlageError } from '../../../shared/error/personenkontext-anlage.error.js';
 import { EntityNotFoundError } from '../../../shared/error/index.js';
 import { DBiamPersonenkontextRepo } from '../persistence/dbiam-personenkontext.repo.js';
+import { RollenArt } from '../../rolle/domain/rolle.enums.js';
+import { OrganisationsTyp } from '../../organisation/domain/organisation.enums.js';
 
 export class PersonenkontextAnlage {
     public organisationId?: string;
@@ -24,6 +26,18 @@ export class PersonenkontextAnlage {
         dBiamPersonenkontextRepo: DBiamPersonenkontextRepo,
     ): PersonenkontextAnlage {
         return new PersonenkontextAnlage(rolleRepo, organisationRepo, dBiamPersonenkontextRepo);
+    }
+
+    // Function to filter organisations, so that only organisations are shown in "new user" dialog, which makes sense regarding the selected rolle.
+    private organisationMatchesRollenart(organisation: OrganisationDo<true>, rolle: Rolle<true>): boolean {
+        if (rolle.rollenart === RollenArt.SYSADMIN) return organisation.typ === OrganisationsTyp.LAND;
+        if (rolle.rollenart === RollenArt.LEIT) return organisation.typ === OrganisationsTyp.SCHULE;
+        if (rolle.rollenart === RollenArt.LERN)
+            return organisation.typ === OrganisationsTyp.SCHULE || organisation.typ === OrganisationsTyp.KLASSE;
+        if (rolle.rollenart === RollenArt.LEHR)
+            return organisation.typ === OrganisationsTyp.SCHULE || organisation.typ === OrganisationsTyp.KLASSE;
+
+        return true;
     }
 
     public async findSchulstrukturknoten(
@@ -52,9 +66,11 @@ export class PersonenkontextAnlage {
         ]);
         allOrganisations.push(...childOrganisations);
 
-        const orgas: OrganisationDo<true>[] = ssks.filter((ssk: OrganisationDo<true>) =>
+        let orgas: OrganisationDo<true>[] = ssks.filter((ssk: OrganisationDo<true>) =>
             allOrganisations.some((organisation: OrganisationDo<true>) => ssk.id === organisation.id),
         );
+
+        orgas = orgas.filter((orga: OrganisationDo<true>) => this.organisationMatchesRollenart(orga, rolleResult));
 
         return orgas.slice(0, limit);
     }

--- a/src/modules/personenkontext/domain/personenkontext-anlage.ts
+++ b/src/modules/personenkontext/domain/personenkontext-anlage.ts
@@ -30,7 +30,8 @@ export class PersonenkontextAnlage {
 
     // Function to filter organisations, so that only organisations are shown in "new user" dialog, which makes sense regarding the selected rolle.
     private organisationMatchesRollenart(organisation: OrganisationDo<true>, rolle: Rolle<true>): boolean {
-        if (rolle.rollenart === RollenArt.SYSADMIN) return organisation.typ === OrganisationsTyp.LAND;
+        if (rolle.rollenart === RollenArt.SYSADMIN)
+            return organisation.typ === OrganisationsTyp.LAND || organisation.typ === OrganisationsTyp.ROOT;
         if (rolle.rollenart === RollenArt.LEIT) return organisation.typ === OrganisationsTyp.SCHULE;
         if (rolle.rollenart === RollenArt.LERN)
             return organisation.typ === OrganisationsTyp.SCHULE || organisation.typ === OrganisationsTyp.KLASSE;


### PR DESCRIPTION
# Description
Adds validation/filtering for organisations for endpoint _/api/personenkontext/schulstrukturknoten_

This endpoint is used in FE to retrieve SSKs matching in a PK with certain rolleId and sskName.

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-655

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.