### PR TITLE
SPSH-687 bugfix EventBus

### DIFF
--- a/docs/event-bus.md
+++ b/docs/event-bus.md
@@ -86,3 +86,5 @@ export class ExampleProvider {
     }
 }
 ```
+
+Using the subscribe-method directly will not bind the execution context (In contrast, events registered by the discovery service will be bound to the parent class). This is fine when using arrow-functions like in the example above, but when you want to use an unbounded function you will need to bind the context yourself using [`Function.prototype.bind()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind).

--- a/src/core/eventbus/event.module.integration-spec.ts
+++ b/src/core/eventbus/event.module.integration-spec.ts
@@ -16,22 +16,24 @@ class TestEvent extends BaseEvent {
 
 @Injectable()
 class TestProvider {
+    // Makes sure that TestProvider and TestController can not be confused by jest
+    public readonly MARKER: symbol = Symbol();
+
     @EventHandler(TestEvent)
     public handleEvent(event: TestEvent): void {
         event.mockCallback(this);
     }
-
-    public undecoratedMethod(): void {}
 }
 
 @Controller({})
 class TestController {
+    // Makes sure that TestProvider and TestController can not be confused by jest
+    public readonly MARKER: symbol = Symbol();
+
     @EventHandler(TestEvent)
     public handleEvent(event: TestEvent): void {
         event.mockCallback(this);
     }
-
-    public undecoratedMethod(): void {}
 }
 
 describe('EventModule (integration test)', () => {

--- a/src/core/eventbus/event.module.integration-spec.ts
+++ b/src/core/eventbus/event.module.integration-spec.ts
@@ -1,0 +1,78 @@
+// eslint-disable-next-line max-classes-per-file
+import { Controller, Injectable } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ConfigTestModule } from '../../../test/utils/config-test.module.js';
+import { BaseEvent } from '../../shared/events/index.js';
+import { EventHandler } from './decorators/event-handler.decorator.js';
+import { EventModule } from './event.module.js';
+import { EventService } from './services/event.service.js';
+
+class TestEvent extends BaseEvent {
+    public constructor(public mockCallback: (context: unknown) => void) {
+        super();
+    }
+}
+
+@Injectable()
+class TestProvider {
+    @EventHandler(TestEvent)
+    public handleEvent(event: TestEvent): void {
+        event.mockCallback(this);
+    }
+
+    public undecoratedMethod(): void {}
+}
+
+@Controller({})
+class TestController {
+    @EventHandler(TestEvent)
+    public handleEvent(event: TestEvent): void {
+        event.mockCallback(this);
+    }
+
+    public undecoratedMethod(): void {}
+}
+
+describe('EventModule (integration test)', () => {
+    let module: TestingModule;
+
+    let eventService: EventService;
+
+    let testProvider: TestProvider;
+    let testController: TestController;
+
+    beforeAll(async () => {
+        module = await Test.createTestingModule({
+            imports: [EventModule, ConfigTestModule],
+            providers: [TestProvider],
+            controllers: [TestController],
+        }).compile();
+
+        await module.init();
+
+        eventService = module.get(EventService);
+        testProvider = module.get(TestProvider);
+        testController = module.get(TestController);
+    });
+
+    afterAll(async () => {
+        await module.close();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('publish', () => {
+        it('should call event handlers with correct context', () => {
+            const mockCallback: jest.Mock = jest.fn();
+
+            eventService.publish(new TestEvent(mockCallback));
+
+            expect(mockCallback).toHaveBeenCalledTimes(2);
+            expect(mockCallback).toHaveBeenCalledWith(testProvider);
+            expect(mockCallback).toHaveBeenCalledWith(testController);
+        });
+    });
+});

--- a/src/core/eventbus/services/event-discovery.service.spec.ts
+++ b/src/core/eventbus/services/event-discovery.service.spec.ts
@@ -38,9 +38,6 @@ describe('EventService', () => {
     let sut: EventDiscoveryService;
     let eventServiceMock: DeepMocked<EventService>;
 
-    let testProvider: TestProvider;
-    let testController: TestController;
-
     beforeAll(async () => {
         module = await Test.createTestingModule({
             imports: [LoggingTestModule, DiscoveryModule],
@@ -56,9 +53,6 @@ describe('EventService', () => {
 
         sut = module.get(EventDiscoveryService);
         eventServiceMock = module.get(EventService);
-
-        testProvider = module.get(TestProvider);
-        testController = module.get(TestController);
     });
 
     afterAll(async () => {
@@ -77,13 +71,13 @@ describe('EventService', () => {
         it('should discover and register all event handlers in controllers', async () => {
             await sut.registerEventHandlers();
 
-            expect(eventServiceMock.subscribe).toHaveBeenCalledWith(TestEvent, testController.handleEvent);
+            expect(eventServiceMock.subscribe).toHaveBeenCalledWith(TestEvent, expect.any(Function));
         });
 
         it('should discover and register all event handlers in providers', async () => {
             await sut.registerEventHandlers();
 
-            expect(eventServiceMock.subscribe).toHaveBeenCalledWith(TestEvent, testProvider.handleEvent);
+            expect(eventServiceMock.subscribe).toHaveBeenCalledWith(TestEvent, expect.any(Function));
         });
 
         it('should return the number of registered handlers', async () => {

--- a/src/core/eventbus/services/event-discovery.service.ts
+++ b/src/core/eventbus/services/event-discovery.service.ts
@@ -34,7 +34,7 @@ export class EventDiscoveryService {
             const eventConstructor: Constructor<BaseEvent> = method.meta;
             const eventHandler: EventHandlerType<BaseEvent> = method.discoveredMethod.handler;
 
-            this.eventService.subscribe(method.meta, eventHandler);
+            this.eventService.subscribe(method.meta, eventHandler.bind(method.discoveredMethod.parentClass.instance));
 
             const parentClassName: string = method.discoveredMethod.parentClass.name;
             const handlerMethodName: string = method.discoveredMethod.methodName;


### PR DESCRIPTION
# Description
EventHandlers registered by the EventDiscoveryService weren't being bound to their parent class, which means `this` inside the handler would not work. This PR fixes the issue.
<!--
  This is a template to add as much information as possible to the pull request, to help the reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-???
- https://ticketsystem.dbildungscloud.de/browse/EW-???
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.