### PR TITLE
SPSH-1291: LdapPersonEntries have objectClass posixAccount

### DIFF
--- a/src/core/ldap/domain/ldap-client.service.ts
+++ b/src/core/ldap/domain/ldap-client.service.ts
@@ -37,6 +37,12 @@ export class LdapClientService {
 
     public static readonly DC_SCHULE_SH_DC_DE: string = 'dc=schule-sh,dc=de';
 
+    public static readonly GID_NUMBER: string = '100'; //because 0 to 99 are used for statically allocated user groups on Unix-systems
+
+    public static readonly UID_NUMBER: string = '100'; //to match the GID_NUMBER rule above and 0 is reserved for super-user
+
+    public static readonly HOME_DIRECTORY: string = 'none'; //highlight it's a dummy value
+
     private mutex: Mutex;
 
     public constructor(
@@ -131,9 +137,13 @@ export class LdapClientService {
                 return { ok: true, value: person };
             }
             const entry: LdapPersonEntry = {
+                uid: lehrerUid,
+                uidNumber: LdapClientService.UID_NUMBER,
+                gidNumber: LdapClientService.GID_NUMBER,
+                homeDirectory: LdapClientService.HOME_DIRECTORY,
                 cn: person.vorname,
                 sn: person.familienname,
-                objectclass: ['inetOrgPerson', 'univentionMail'],
+                objectclass: ['inetOrgPerson', 'univentionMail', 'posixAccount'],
                 mailPrimaryAddress: mail ?? ``,
                 mailAlternativeAddress: mail ?? ``,
             };

--- a/src/core/ldap/domain/ldap.types.ts
+++ b/src/core/ldap/domain/ldap.types.ts
@@ -1,4 +1,8 @@
 export type LdapPersonEntry = {
+    uid: string; //required for posixAccount objectClass
+    uidNumber: string; //required for posixAccount objectClass
+    gidNumber: string; //required for posixAccount objectClass
+    homeDirectory: string; //required for posixAccount objectClass
     cn: string;
     sn: string;
     mailPrimaryAddress?: string;
@@ -9,6 +13,5 @@ export type LdapPersonEntry = {
 };
 
 export enum LdapEntityType {
-    SCHULE = 'SCHULE',
     LEHRER = 'LEHRER',
 }


### PR DESCRIPTION
# Description
Created entries in LDAP (Lehrer) have the object-class 'posixAccount'.

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1291

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.