### PR TITLE
SPSH-1423: Disable the existing email when the user does not have any PKs anymore.

### DIFF
--- a/src/modules/email/domain/email-address.ts
+++ b/src/modules/email/domain/email-address.ts
@@ -81,6 +81,10 @@ export class EmailAddress<WasPersisted extends boolean> {
         return this.addressStatus === EmailAddressStatus.ENABLED || this.addressStatus === EmailAddressStatus.REQUESTED;
     }
 
+    public get disabled(): boolean {
+        return this.addressStatus === EmailAddressStatus.DISABLED;
+    }
+
     public get personId(): PersonID {
         return this.addressPersonId;
     }

--- a/src/modules/email/domain/email-event-handler.spec.ts
+++ b/src/modules/email/domain/email-event-handler.spec.ts
@@ -395,18 +395,7 @@ describe('Email Event Handler', () => {
                 rolleRepoMock.findByIds.mockResolvedValueOnce(rolleMap);
                 serviceProviderRepoMock.findByIds.mockResolvedValueOnce(new Map<string, ServiceProvider<true>>());
 
-                // eslint-disable-next-line @typescript-eslint/require-await
-                emailRepoMock.findEnabledByPerson.mockImplementationOnce(async (personId: PersonID) => {
-                    return new EmailAddress<true>(
-                        faker.string.uuid(),
-                        faker.date.past(),
-                        faker.date.recent(),
-                        personId,
-                        faker.internet.email(),
-                        EmailAddressStatus.ENABLED,
-                    );
-                });
-
+                emailRepoMock.findByPersonSortedByUpdatedAtDesc.mockResolvedValueOnce([getEmail()]);
                 emailRepoMock.save.mockResolvedValueOnce(new EmailAddressNotFoundError(fakeEmailAddressString)); //mock: error during saving the entity
 
                 await emailEventHandler.handlePersonenkontextUpdatedEvent(event);
@@ -440,17 +429,16 @@ describe('Email Event Handler', () => {
                         EmailAddressStatus.DISABLED,
                     );
 
-                    // eslint-disable-next-line @typescript-eslint/require-await
-                    emailRepoMock.findEnabledByPerson.mockImplementationOnce(async (personId: PersonID) => {
-                        return new EmailAddress<true>(
+                    emailRepoMock.findByPersonSortedByUpdatedAtDesc.mockResolvedValueOnce([
+                        EmailAddress.construct(
                             faker.string.uuid(),
                             faker.date.past(),
                             faker.date.recent(),
-                            personId,
+                            fakePersonId,
                             faker.internet.email(),
                             status,
-                        );
-                    });
+                        ),
+                    ]);
 
                     emailRepoMock.save.mockResolvedValueOnce(emailAddress);
                     await emailEventHandler.handlePersonenkontextUpdatedEvent(event);

--- a/src/modules/email/domain/email-event-handler.spec.ts
+++ b/src/modules/email/domain/email-event-handler.spec.ts
@@ -891,21 +891,6 @@ describe('Email Event Handler', () => {
                 expect(loggerMock.info).toHaveBeenCalledWith(`RolleUpdatedEvent affects:2 persons`);
             });
         });
-
-        describe('when rolle is updated but person should not get an email-address by event', () => {
-            it('should log info', async () => {
-                dbiamPersonenkontextRepoMock.findByRolle.mockResolvedValueOnce(personenkontexte);
-
-                //mock that no email-address is necessary for person to test handlePerson
-                dbiamPersonenkontextRepoMock.findByPerson.mockResolvedValue([]);
-                rolleRepoMock.findByIds.mockResolvedValue(new Map<string, Rolle<true>>());
-                serviceProviderRepoMock.findByIds.mockResolvedValue(new Map<string, ServiceProvider<true>>());
-
-                await emailEventHandler.handleRolleUpdatedEvent(event);
-
-                expect(loggerMock.info).toHaveBeenCalledWith(`Person with id:${fakePersonId} does not need an email`);
-            });
-        });
     });
 
     describe('handleOxUserAttributesCreatedEvent', () => {

--- a/src/modules/email/domain/email-event-handler.ts
+++ b/src/modules/email/domain/email-event-handler.ts
@@ -293,19 +293,24 @@ export class EmailEventHandler {
         } else {
             //If user does not have any PK with SP referencing email, we have to disable any existing email
             //Even FAILED emails are disabled, because they are not used
-            const existingEmail: Option<EmailAddress<true>> = await this.emailRepo.findEnabledByPerson(personId);
-            if (existingEmail) {
-                this.logger.info(`Existing email found for personId:${personId}, address:${existingEmail.address}`);
-                if (!existingEmail.disabled) {
-                    existingEmail.disable();
-                    const persistenceResult: EmailAddress<true> | DomainError =
-                        await this.emailRepo.save(existingEmail);
-                    if (persistenceResult instanceof EmailAddress) {
-                        this.logger.info(`Disabled and saved address:${persistenceResult.address}`);
-                    } else {
-                        this.logger.error(`Could not disable email, error is ${persistenceResult.message}`);
+            const existingEmails: Option<EmailAddress<true>[]> =
+                await this.emailRepo.findByPersonSortedByUpdatedAtDesc(personId);
+            if (existingEmails) {
+                /* eslint-disable no-await-in-loop */
+                for (const existingEmail of existingEmails) {
+                    this.logger.info(`Existing email found for personId:${personId}, address:${existingEmail.address}`);
+                    if (!existingEmail.disabled) {
+                        existingEmail.disable();
+                        const persistenceResult: EmailAddress<true> | DomainError =
+                            await this.emailRepo.save(existingEmail); //We have to use await in a loop because of persistenceResult
+                        if (persistenceResult instanceof EmailAddress) {
+                            this.logger.info(`Disabled and saved address:${persistenceResult.address}`);
+                        } else {
+                            this.logger.error(`Could not disable email, error is ${persistenceResult.message}`);
+                        }
                     }
                 }
+                /* eslint-disable no-await-in-loop */
             }
         }
     }

--- a/src/modules/email/domain/email-event-handler.ts
+++ b/src/modules/email/domain/email-event-handler.ts
@@ -292,10 +292,11 @@ export class EmailEventHandler {
             await this.createOrEnableEmail(personId, pkOfRolleWithSPReference.organisationId);
         } else {
             //If user does not have any PK with SP referencing email, we have to disable any existing email
+            //Even FAILED emails are disabled, because they are not used
             const existingEmail: Option<EmailAddress<true>> = await this.emailRepo.findEnabledByPerson(personId);
             if (existingEmail) {
                 this.logger.info(`Existing email found for personId:${personId}, address:${existingEmail.address}`);
-                if (existingEmail.enabledOrRequested) {
+                if (!existingEmail.disabled) {
                     existingEmail.disable();
                     const persistenceResult: EmailAddress<true> | DomainError =
                         await this.emailRepo.save(existingEmail);


### PR DESCRIPTION
# Description
- Disable any existing email address when the lehrer does not have any PKs
- Added unit tests

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/SPSH-1423

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.