### PR TITLE
SPSH-1501: Removal as member from OX-groups

### DIFF
--- a/src/modules/email/domain/email-event-handler.spec.ts
+++ b/src/modules/email/domain/email-event-handler.spec.ts
@@ -1107,8 +1107,8 @@ describe('Email Event Handler', () => {
 
                 await emailEventHandler.handleOxMetadataInKeycloakChangedEvent(event);
 
-                expect(loggerMock.error).toHaveBeenLastCalledWith(
-                    `Cannot find requested email-address for person with personId:${event.personId}, enabling not possible`,
+                expect(loggerMock.info).toHaveBeenLastCalledWith(
+                    `Cannot find requested email-address for person with personId:${event.personId}, enabling not necessary`,
                 );
             });
         });

--- a/src/modules/email/domain/email-event-handler.ts
+++ b/src/modules/email/domain/email-event-handler.ts
@@ -247,8 +247,8 @@ export class EmailEventHandler {
         const email: Option<EmailAddress<true>> = await this.emailRepo.findRequestedByPerson(event.personId);
 
         if (!email) {
-            return this.logger.error(
-                `Cannot find requested email-address for person with personId:${event.personId}, enabling not possible`,
+            return this.logger.info(
+                `Cannot find requested email-address for person with personId:${event.personId}, enabling not necessary`,
             );
         }
 

--- a/src/modules/ox/actions/group/remove-member-from-group.action.ts
+++ b/src/modules/ox/actions/group/remove-member-from-group.action.ts
@@ -1,12 +1,11 @@
 import { DomainError } from '../../../../shared/error/domain.error.js';
 import { NS2_SCHEMA, NS6_SCHEMA, TNS_SCHEMA } from '../../schemas.js';
 import { OxBaseAction, OXRequestStatus } from '../ox-base-action.js';
-import { AddMemberToGroupResponseBody } from './add-member-to-group.action.js';
 import { GroupMemberParams } from './ox-group.types.js';
 
 export type RemoveMemberFromGroupResponse = {
     status: OXRequestStatus;
-    data: AddMemberToGroupResponseBody;
+    data: RemoveMemberFromGroupResponseBody;
 };
 
 export type RemoveMemberFromGroupResponseBody = {

--- a/src/modules/ox/domain/ox-event-handler.spec.ts
+++ b/src/modules/ox/domain/ox-event-handler.spec.ts
@@ -24,6 +24,7 @@ import { EntityCouldNotBeCreated } from '../../../shared/error/index.js';
 import { OXGroupID, OXUserID } from '../../../shared/types/ox-ids.types.js';
 import { ListGroupsAction } from '../actions/group/list-groups.action.js';
 import { EmailAddressAlreadyExistsEvent } from '../../../shared/events/email-address-already-exists.event.js';
+import { EmailAddressDisabledEvent } from '../../../shared/events/email-address-disabled.event.js';
 
 describe('OxEventHandler', () => {
     let module: TestingModule;
@@ -167,7 +168,7 @@ describe('OxEventHandler', () => {
 
                 expect(oxServiceMock.send).toHaveBeenCalledWith(expect.any(CreateUserAction));
                 expect(loggerMock.error).toHaveBeenCalledWith(
-                    `Could Not Create OxGroup with name:lehrer-${fakeDstNr}, displayName:Lehrer of ${fakeDstNr}`,
+                    `Could Not Create OxGroup with name:lehrer-${fakeDstNr}, displayName:lehrer-${fakeDstNr}`,
                 );
                 expect(eventServiceMock.publish).toHaveBeenCalledTimes(0);
             });
@@ -217,7 +218,7 @@ describe('OxEventHandler', () => {
                     value: {
                         groups: [
                             {
-                                displayname: `Lehrer of ${fakeDstNr}`,
+                                displayname: `lehrer-${fakeDstNr}`,
                                 id: 'id',
                                 name: `lehrer-${fakeDstNr}`,
                                 memberIds: [],
@@ -370,13 +371,13 @@ describe('OxEventHandler', () => {
                     value: {
                         groups: [
                             {
-                                displayname: `Lehrer of ${fakeDstNr}`,
+                                displayname: `lehrer-${fakeDstNr}`,
                                 id: 'id',
                                 name: `lehrer-${fakeDstNr}`,
                                 memberIds: [],
                             },
                             {
-                                displayname: `Lehrer of ${fakeDstNr}`,
+                                displayname: `lehrer-${fakeDstNr}`,
                                 id: 'id',
                                 name: `lehrer-${fakeDstNr}-`,
                                 memberIds: [],
@@ -1045,6 +1046,131 @@ describe('OxEventHandler', () => {
                         `Failed to add user with personId:${event.personId} to OX group with id:${fakeOXGroupId}`,
                     ),
                 );
+            });
+        });
+    });
+
+    describe('handleEmailAddressDisabledEvent', () => {
+        let personId: PersonID;
+        let username: string;
+        let oxUserId: OXUserID;
+        let event: EmailAddressDisabledEvent;
+        let person: Person<true>;
+
+        beforeEach(() => {
+            jest.resetAllMocks();
+            personId = faker.string.uuid();
+            username = faker.internet.userName();
+            oxUserId = faker.string.numeric();
+            event = new EmailAddressDisabledEvent(personId, username);
+            person = createMock<Person<true>>({
+                email: faker.internet.email(),
+                referrer: username,
+                oxUserId: oxUserId,
+            });
+        });
+
+        describe('when handler is disabled', () => {
+            it('should log and skip processing when not enabled', async () => {
+                sut.ENABLED = false;
+                await sut.handleEmailAddressDisabledEvent(event);
+
+                expect(loggerMock.info).toHaveBeenCalledWith('Not enabled, ignoring event');
+            });
+        });
+
+        describe('when person is not found', () => {
+            it('should log error if person does not exist', async () => {
+                personRepositoryMock.findById.mockResolvedValueOnce(undefined);
+
+                await sut.handleEmailAddressDisabledEvent(event);
+
+                expect(loggerMock.error).toHaveBeenCalledWith(`Could Not Find Person For personId:${event.personId}`);
+            });
+        });
+
+        describe('when person is found BUT has NO oxUserId', () => {
+            it('should log error if person does not have a oxUserId', async () => {
+                personRepositoryMock.findById.mockResolvedValueOnce(createMock<Person<true>>({ oxUserId: undefined }));
+
+                await sut.handleEmailAddressDisabledEvent(event);
+
+                expect(loggerMock.error).toHaveBeenCalledWith(
+                    `Could Not Remove Person From OxGroups, No OxUserId For personId:${event.personId}`,
+                );
+            });
+        });
+
+        describe('when listing groups for user fails', () => {
+            it('should log error', async () => {
+                personRepositoryMock.findById.mockResolvedValueOnce(person);
+
+                //mock listing groups results in error
+                oxServiceMock.send.mockResolvedValueOnce({
+                    ok: false,
+                    error: new OxError(),
+                });
+
+                await sut.handleEmailAddressDisabledEvent(event);
+
+                expect(loggerMock.error).toHaveBeenCalledWith(
+                    `Retrieving OxGroups For OxUser Failed, personId:${event.personId}`,
+                );
+            });
+        });
+
+        describe('when removing user from groups fails for at least one group', () => {
+            it('should log error', async () => {
+                personRepositoryMock.findById.mockResolvedValueOnce(person);
+
+                //mock listing groups
+                oxServiceMock.send.mockResolvedValueOnce({
+                    ok: true,
+                    value: {
+                        groups: [
+                            {
+                                displayname: 'group1-displayname',
+                                id: 'group1-id',
+                                name: 'group1-name',
+                                memberIds: [oxUserId],
+                            },
+                            {
+                                displayname: 'group2-displayname',
+                                id: 'group2-id',
+                                name: 'group2-name',
+                                memberIds: [oxUserId],
+                            },
+                        ],
+                    },
+                });
+
+                //mock removing member from group-1 succeeds
+                oxServiceMock.send.mockResolvedValueOnce({
+                    ok: true,
+                    value: {
+                        status: {
+                            code: 'success',
+                        },
+                        data: 'body',
+                    },
+                });
+
+                //mock removing member from group-2 results in error
+                oxServiceMock.send.mockResolvedValueOnce({
+                    ok: false,
+                    error: new OxError(),
+                });
+
+                await sut.handleEmailAddressDisabledEvent(event);
+
+                expect(loggerMock.info).toHaveBeenCalledWith(
+                    `Successfully Removed OxUser From OxGroup, oxUserId:${oxUserId}, oxGroupId:group1-id`,
+                );
+
+                expect(loggerMock.error).toHaveBeenCalledWith(
+                    `Could Not Remove OxUser From OxGroup, oxUserId:${oxUserId}, oxGroupId:group2-id`,
+                );
+                //expect(loggerMock.error).toHaveBeenCalledWith(`Failed To Removed OxUser From All Non-Standard OxGroups, personId:${event.personId}, oxUserId:${oxUserId}`);
             });
         });
     });

--- a/src/modules/ox/domain/ox-event-handler.ts
+++ b/src/modules/ox/domain/ox-event-handler.ts
@@ -196,10 +196,12 @@ export class OxEventHandler {
         const oxGroups: OXGroup[] = listGroupsForUserResponse.value.groups;
         const oxUserId: OXUserID = person.oxUserId;
 
-        //logging of results is done in removeOxUserFromOxGroup
-        await Promise.allSettled(
-            oxGroups.map((oxGroup: OXGroup) => this.removeOxUserFromOxGroup(oxGroup.id, oxUserId)),
-        );
+        // The sent Ox-request should be awaited explicitly to avoid failures due to async execution in OX-Database (SQL-exceptions)
+        /* eslint-disable no-await-in-loop */
+        for (const oxGroup of oxGroups) {
+            //logging of results is done in removeOxUserFromOxGroup
+            await this.removeOxUserFromOxGroup(oxGroup.id, oxUserId);
+        }
     }
 
     private async getMostRecentRequestedEmailAddress(personId: PersonID): Promise<Option<EmailAddress<true>>> {

--- a/src/shared/config/ox.config.ts
+++ b/src/shared/config/ox.config.ts
@@ -1,4 +1,4 @@
-import { IsBooleanString, IsNumberString, IsString } from 'class-validator';
+import { IsBooleanString, IsNumberString, IsOptional, IsString } from 'class-validator';
 
 export class OxConfig {
     @IsBooleanString()
@@ -12,6 +12,10 @@ export class OxConfig {
 
     @IsString()
     public readonly CONTEXT_NAME!: string;
+
+    @IsNumberString()
+    @IsOptional()
+    public readonly STANDARD_GROUP_ID?: string;
 
     @IsString()
     public readonly USERNAME!: string;


### PR DESCRIPTION
# Description
- remove OxUser as member from any OxGroups when EmailAddressDisabledEvent is triggered
- change logging status when enabling of a REQUESTED email-address is not necessary in an event-handler from error to info

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1501
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1536

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.