### PR TITLE
SPSH-1566: OX: Entfernung aus Standard-Gruppe skippen

### DIFF
--- a/src/shared/config/ox.config.ts
+++ b/src/shared/config/ox.config.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsNumberString, IsString } from 'class-validator';
+import { IsBoolean, IsNumberString, IsOptional, IsString } from 'class-validator';
 
 export class OxConfig {
     @IsBoolean()
@@ -12,6 +12,10 @@ export class OxConfig {
 
     @IsString()
     public readonly CONTEXT_NAME!: string;
+
+    @IsNumberString()
+    @IsOptional()
+    public readonly STANDARD_GROUP_ID?: string;
 
     @IsString()
     public readonly USERNAME!: string;

--- a/test/config.test.json
+++ b/test/config.test.json
@@ -68,7 +68,8 @@
         "ENABLED": false,
         "ENDPOINT": "https://ox_ip:ox_port/webservices/",
         "USERNAME": "username",
-        "PASSWORD": "password"
+        "PASSWORD": "password",
+        "STANDARD_GROUP_ID": "1"
     },
     "IMPORT": {
         "IMPORT_FILE_MAXGROESSE_IN_MB": 1


### PR DESCRIPTION
# Description
- introduce OX-config optional parameter STANDARD_GROUP_ID
- skip removing OxUsers from the OxGroup that is defined as StandardGroup

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1566

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.