### PR TITLE
Dbp 1118 redis helm chsrt improvement release

### DIFF
--- a/charts/dbildungs-iam-server/Chart.yaml
+++ b/charts/dbildungs-iam-server/Chart.yaml
@@ -4,8 +4,3 @@ version: 0.2.0
 description: dBildungs-IAM-server
 type: application
 appVersion: ""
-dependencies:
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.3.0
-  condition: redis.enabled 

--- a/charts/dbildungs-iam-server/config/config.json
+++ b/charts/dbildungs-iam-server/config/config.json
@@ -24,7 +24,7 @@
     "SERVICE_CLIENT_ID": "spsh-service"
   },
   "REDIS": {
-    "HOST": "dbildungs-iam-server-redis",
+    "HOST": "dbildungs-iam-redis-master.spsh.svc.cluster.local",
     "PORT": 6379,
     "USERNAME": "default",
     "PASSWORD": "",

--- a/charts/dbildungs-iam-server/values.yaml
+++ b/charts/dbildungs-iam-server/values.yaml
@@ -61,7 +61,7 @@ backend:
   replicaCount: 1
   image:
     repository: ghcr.io/dbildungsplattform/dbildungs-iam-server
-    tag: 'DBP-1118'
+    tag: ''
     pullPolicy: Always
   containerPorts:
     http: 8080

--- a/charts/dbildungs-iam-server/values.yaml
+++ b/charts/dbildungs-iam-server/values.yaml
@@ -61,7 +61,7 @@ backend:
   replicaCount: 1
   image:
     repository: ghcr.io/dbildungsplattform/dbildungs-iam-server
-    tag: ''
+    tag: 'DBP-1118'
     pullPolicy: Always
   containerPorts:
     http: 8080
@@ -136,45 +136,6 @@ backend:
     stepUpTimeoutInSeconds: 900
     stepUpTimeoutEnabled: 'false'
 
-redis:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: bitnami/redis
-    tag: 7.4.1-debian-12-r2
-  replica:
-  # turn back
-    replicaCount: 3
-    # needed for redis masterservice
-    automountServiceAccountToken: true
-  sentinel:
-    enabled: true
-    masterService:
-      enabled: true
-  pdb:
-    create: false
-  networkPolicy:
-    enabled: false
-  serviceAccount:
-    create: false
-  auth:
-    existingSecret: ''
-  podLabels:
-    app.kubernetes.io/component: server-redis
-  commonLabels:
-    app.kubernetes.io/name: dbildungs-iam-server
-  resources:
-    limits:
-      cpu: 300m
-      memory: 512Mi
-    requests:
-      cpu: 125m
-      memory: 128Mi
-  metrics:
-    enabled: true
-  # needed for redis masterservice
-  rbac:
-    create: true
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/charts/dbildungs-iam-server/values.yaml
+++ b/charts/dbildungs-iam-server/values.yaml
@@ -145,6 +145,8 @@ redis:
   replica:
   # turn back
     replicaCount: 3
+    # needed for redis masterservice
+    automountServiceAccountToken: true
   sentinel:
     enabled: true
     masterService:
@@ -170,7 +172,9 @@ redis:
       memory: 128Mi
   metrics:
     enabled: true
-
+  # needed for redis masterservice
+  rbac:
+    create: true
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/charts/dbildungs-iam-server/values.yaml
+++ b/charts/dbildungs-iam-server/values.yaml
@@ -143,9 +143,12 @@ redis:
     repository: bitnami/redis
     tag: 7.4.1-debian-12-r2
   replica:
-    replicaCount: 1
+  # turn back
+    replicaCount: 3
   sentinel:
     enabled: true
+    masterService:
+      enabled: true
   pdb:
     create: false
   networkPolicy:


### PR DESCRIPTION
# Description
Switch to global redis and connect backend to master, so that it can write. Without this, the backend will select a random Redis-node, which may or may not be writable. Writing to a read-only replica crashes the backend and sends a 403 to the client. This will happen frequently after deployment, until all backend pods have randomly selected the Redis-master.

Config has been verified on Staging and Prod.