### PR TITLE
SPSH-1703: remove LDAP-user from LDAP-group instead of deleting on PersonenkontextUpdatedEvent

### DIFF
--- a/src/core/ldap/domain/ldap-client.service.ts
+++ b/src/core/ldap/domain/ldap-client.service.ts
@@ -7,7 +7,7 @@ import { LdapInstanceConfig } from '../ldap-instance-config.js';
 import { UsernameRequiredError } from '../../../modules/person/domain/username-required.error.js';
 import { Mutex } from 'async-mutex';
 import { LdapSearchError } from '../error/ldap-search.error.js';
-import { PersonID, PersonReferrer } from '../../../shared/types/aggregate-ids.types.js';
+import { OrganisationKennung, PersonID, PersonReferrer } from '../../../shared/types/aggregate-ids.types.js';
 import { EventService } from '../../eventbus/services/event.service.js';
 import { LdapPersonEntryChangedEvent } from '../../../shared/events/ldap-person-entry-changed.event.js';
 import { LdapEmailAddressError } from '../error/ldap-email-address.error.js';
@@ -120,14 +120,22 @@ export class LdapClientService {
         );
     }
 
-    public async deleteLehrer(person: PersonData, orgaKennung: string, domain: string): Promise<Result<PersonData>> {
+    public async deleteLehrer(
+        person: PersonData,
+        orgaKennung: OrganisationKennung,
+        domain: string,
+    ): Promise<Result<PersonData>> {
         return this.executeWithRetry(
             () => this.deleteLehrerInternal(person, orgaKennung, domain),
             LdapClientService.DEFAULT_RETRIES,
         );
     }
 
-    public async addPersonToGroup(personUid: string, orgaKennung: string, lehrerUid: string): Promise<Result<boolean>> {
+    public async addPersonToGroup(
+        personUid: string,
+        orgaKennung: OrganisationKennung,
+        lehrerUid: string,
+    ): Promise<Result<boolean>> {
         return this.executeWithRetry(
             () => this.addPersonToGroupInternal(personUid, orgaKennung, lehrerUid),
             LdapClientService.DEFAULT_RETRIES,
@@ -147,7 +155,7 @@ export class LdapClientService {
 
     public async removePersonFromGroup(
         referrer: PersonReferrer,
-        orgaKennung: string,
+        orgaKennung: OrganisationKennung,
         lehrerUid: string,
     ): Promise<Result<boolean>> {
         return this.executeWithRetry(
@@ -158,7 +166,7 @@ export class LdapClientService {
 
     public async removePersonFromGroupByUsernameAndKennung(
         referrer: PersonReferrer,
-        orgaKennung: string,
+        orgaKennung: OrganisationKennung,
         domain: string,
     ): Promise<Result<boolean>> {
         const rootName: Result<string> = this.getRootNameOrError(domain);
@@ -531,7 +539,7 @@ export class LdapClientService {
 
     private async deleteLehrerInternal(
         person: PersonData,
-        orgaKennung: string,
+        orgaKennung: OrganisationKennung,
         domain: string,
     ): Promise<Result<PersonData>> {
         const rootName: Result<string> = this.getRootNameOrError(domain);
@@ -667,7 +675,7 @@ export class LdapClientService {
 
     private async addPersonToGroupInternal(
         personUid: string,
-        orgaKennung: string,
+        orgaKennung: OrganisationKennung,
         lehrerUid: string,
     ): Promise<Result<boolean>> {
         const groupId: string = 'lehrer-' + orgaKennung;
@@ -749,7 +757,7 @@ export class LdapClientService {
 
     private async removePersonFromGroupInternal(
         referrer: PersonReferrer,
-        orgaKennung: string,
+        orgaKennung: OrganisationKennung,
         lehrerUid: string,
     ): Promise<Result<boolean>> {
         const groupId: string = 'lehrer-' + orgaKennung;

--- a/src/core/ldap/domain/ldap-event-handler.spec.ts
+++ b/src/core/ldap/domain/ldap-event-handler.spec.ts
@@ -509,7 +509,7 @@ describe('LDAP Event Handler', () => {
 
             await ldapEventHandler.handlePersonenkontextUpdatedEvent(event);
 
-            expect(ldapClientServiceMock.deleteLehrer).toHaveBeenCalledTimes(1);
+            expect(ldapClientServiceMock.removePersonFromGroupByUsernameAndKennung).toHaveBeenCalledTimes(1);
         });
 
         it('should NOT call ldap client for deleting person in LDAP when person still has at least one PK with rollenArt LEHR left', async () => {
@@ -589,7 +589,7 @@ describe('LDAP Event Handler', () => {
             await ldapEventHandler.handlePersonenkontextUpdatedEvent(event);
 
             expect(loggerMock.error).toHaveBeenLastCalledWith(
-                `LdapClientService deleteLehrer NOT called, because organisation:${removedOrgaId} has no valid emailDomain`,
+                `LdapClientService removePersonFromGroup NOT called, because organisation:${removedOrgaId} has no valid emailDomain`,
             );
             expect(ldapClientServiceMock.deleteLehrer).toHaveBeenCalledTimes(0);
         });
@@ -627,7 +627,7 @@ describe('LDAP Event Handler', () => {
             });
         });
 
-        it('should execute without errors, if deletion of lehrer fails', async () => {
+        it('should execute without errors, if removePersonFromGroup fails', async () => {
             const event: PersonenkontextUpdatedEvent = new PersonenkontextUpdatedEvent(
                 {
                     id: faker.string.uuid(),
@@ -649,7 +649,7 @@ describe('LDAP Event Handler', () => {
                 ],
                 [],
             );
-            ldapClientServiceMock.deleteLehrer.mockResolvedValueOnce({
+            ldapClientServiceMock.removePersonFromGroupByUsernameAndKennung.mockResolvedValueOnce({
                 ok: false,
                 error: new Error('Error'),
             });
@@ -658,7 +658,7 @@ describe('LDAP Event Handler', () => {
 
             await ldapEventHandler.handlePersonenkontextUpdatedEvent(event);
 
-            expect(ldapClientServiceMock.deleteLehrer).toHaveBeenCalledTimes(1);
+            expect(ldapClientServiceMock.removePersonFromGroupByUsernameAndKennung).toHaveBeenCalledTimes(1);
         });
 
         it('should log an error when a removed personenkontext has no orgaKennung', async () => {
@@ -718,7 +718,7 @@ describe('LDAP Event Handler', () => {
             expect(ldapClientServiceMock.createLehrer).toHaveBeenCalledTimes(0);
         });
 
-        it('should log error when error occurs while delete Lehrer', async () => {
+        it('should log error when error occurs in removePersonFromGroupByUsernameAndKennung', async () => {
             const event: PersonenkontextUpdatedEvent = new PersonenkontextUpdatedEvent(
                 {
                     id: faker.string.uuid(),
@@ -751,12 +751,14 @@ describe('LDAP Event Handler', () => {
             );
 
             organisationRepositoryMock.findEmailDomainForOrganisation.mockResolvedValueOnce('schule-sh.de');
-            ldapClientServiceMock.deleteLehrer.mockRejectedValueOnce(new Error('deleteLehrer error'));
+            ldapClientServiceMock.removePersonFromGroupByUsernameAndKennung.mockRejectedValueOnce(
+                new Error('removePersonFromGroup error'),
+            );
 
             await ldapEventHandler.handlePersonenkontextUpdatedEvent(event);
 
             expect(loggerMock.error).toHaveBeenCalledTimes(1);
-            expect(loggerMock.error).toHaveBeenCalledWith(expect.stringContaining('Error while deleteLehrer:'));
+            expect(loggerMock.error).toHaveBeenCalledWith(expect.stringContaining('Error in removePersonFromGroup:'));
         });
 
         it('should log error when error occurs while getEmailDomainForOrganisationId deleting person', async () => {
@@ -797,7 +799,7 @@ describe('LDAP Event Handler', () => {
 
             expect(loggerMock.error).toHaveBeenCalledTimes(1);
             expect(loggerMock.error).toHaveBeenCalledWith(
-                expect.stringContaining('Error while getEmailDomainForOrganisationId:'),
+                expect.stringContaining('Error in getEmailDomainForOrganisationId:'),
             );
         });
 
@@ -839,7 +841,7 @@ describe('LDAP Event Handler', () => {
             await ldapEventHandler.handlePersonenkontextUpdatedEvent(event);
 
             expect(loggerMock.error).toHaveBeenCalledTimes(1);
-            expect(loggerMock.error).toHaveBeenCalledWith(expect.stringContaining('Error while createLehrer:'));
+            expect(loggerMock.error).toHaveBeenCalledWith(expect.stringContaining('Error in createLehrer:'));
         });
 
         it('should log error when error occurs while getEmailDomainForOrganisationId adding person', async () => {
@@ -880,7 +882,7 @@ describe('LDAP Event Handler', () => {
 
             expect(loggerMock.error).toHaveBeenCalledTimes(1);
             expect(loggerMock.error).toHaveBeenCalledWith(
-                expect.stringContaining('Error while getEmailDomainForOrganisationId:'),
+                expect.stringContaining('Error in getEmailDomainForOrganisationId:'),
             );
         });
     });
@@ -920,7 +922,7 @@ describe('LDAP Event Handler', () => {
             await ldapEventHandler.handleEmailAddressChangedEvent(event);
 
             expect(loggerMock.info).toHaveBeenLastCalledWith(
-                `Received EmailAddressChangedEvent, personId:${event.personId}, newEmailAddress: ${event.newAddress}`,
+                `Received EmailAddressChangedEvent, personId:${event.personId}, newEmailAddress: ${event.newAddress}, oldEmailAddress: ${event.oldAddress}`,
             );
             expect(ldapClientServiceMock.changeEmailAddressByPersonId).toHaveBeenCalledTimes(1);
         });

--- a/src/core/ldap/domain/ldap-event-handler.ts
+++ b/src/core/ldap/domain/ldap-event-handler.ts
@@ -165,27 +165,31 @@ export class LdapEventHandler {
                     }
                     return this.getEmailDomainForOrganisationId(pk.orgaId)
                         .catch((error: Error) => {
-                            this.logger.error(`Error while getEmailDomainForOrganisationId: ${error.message}`);
+                            this.logger.error(`Error in getEmailDomainForOrganisationId: ${error.message}`);
                             return Promise.reject(error);
                         })
                         .then((emailDomain: Result<string>) => {
                             if (emailDomain.ok) {
                                 this.logger.info(`Call LdapClientService because rollenArt is LEHR, pkId: ${pk.id}`);
                                 return this.ldapClientService
-                                    .deleteLehrer(event.person, pk.orgaKennung!, emailDomain.value)
-                                    .then((deletionResult: Result<PersonData>) => {
-                                        if (!deletionResult.ok) {
-                                            this.logger.error(deletionResult.error.message);
+                                    .removePersonFromGroupByUsernameAndKennung(
+                                        event.person.referrer!,
+                                        pk.orgaKennung!,
+                                        emailDomain.value,
+                                    )
+                                    .then((removeFromGroupResult: Result<boolean>) => {
+                                        if (!removeFromGroupResult.ok) {
+                                            this.logger.error(removeFromGroupResult.error.message);
                                         }
-                                        return deletionResult;
+                                        return removeFromGroupResult;
                                     })
                                     .catch((error: Error) => {
-                                        this.logger.error(`Error while deleteLehrer: ${error.message}`);
+                                        this.logger.error(`Error in removePersonFromGroup: ${error.message}`);
                                         return Promise.reject(error);
                                     });
                             } else {
                                 this.logger.error(
-                                    `LdapClientService deleteLehrer NOT called, because organisation:${pk.orgaId} has no valid emailDomain`,
+                                    `LdapClientService removePersonFromGroup NOT called, because organisation:${pk.orgaId} has no valid emailDomain`,
                                 );
                                 return Promise.reject(new Error('Invalid email domain'));
                             }
@@ -204,7 +208,7 @@ export class LdapEventHandler {
                     }
                     return this.getEmailDomainForOrganisationId(pk.orgaId)
                         .catch((error: Error) => {
-                            this.logger.error(`Error while getEmailDomainForOrganisationId: ${error.message}`);
+                            this.logger.error(`Error in getEmailDomainForOrganisationId: ${error.message}`);
                             return Promise.reject(error);
                         })
                         .then((emailDomain: Result<string>) => {
@@ -218,7 +222,7 @@ export class LdapEventHandler {
                                         return creationResult;
                                     })
                                     .catch((error: Error) => {
-                                        this.logger.error(`Error while createLehrer: ${error.message}`);
+                                        this.logger.error(`Error in createLehrer: ${error.message}`);
                                         return Promise.reject(error);
                                     });
                             } else {
@@ -244,7 +248,7 @@ export class LdapEventHandler {
     @EventHandler(EmailAddressChangedEvent)
     public async handleEmailAddressChangedEvent(event: EmailAddressChangedEvent): Promise<void> {
         this.logger.info(
-            `Received EmailAddressChangedEvent, personId:${event.personId}, newEmailAddress: ${event.newAddress}`,
+            `Received EmailAddressChangedEvent, personId:${event.personId}, newEmailAddress: ${event.newAddress}, oldEmailAddress: ${event.oldAddress}`,
         );
 
         await this.ldapClientService.changeEmailAddressByPersonId(event.personId, event.referrer, event.newAddress);

--- a/src/modules/email/domain/email-event-handler.ts
+++ b/src/modules/email/domain/email-event-handler.ts
@@ -8,7 +8,7 @@ import { ServiceProvider } from '../../service-provider/domain/service-provider.
 import { ServiceProviderKategorie } from '../../service-provider/domain/service-provider.enum.js';
 import { PersonDeletedEvent } from '../../../shared/events/person-deleted.event.js';
 import { DomainError, EntityNotFoundError } from '../../../shared/error/index.js';
-import { OrganisationID, PersonID, PersonReferrer } from '../../../shared/types/index.js';
+import { OrganisationID, OrganisationKennung, PersonID, PersonReferrer } from '../../../shared/types/index.js';
 import { EmailAddressEntity } from '../persistence/email-address.entity.js';
 import { EmailAddressNotFoundError } from '../error/email-address-not-found.error.js';
 import { EmailRepo } from '../persistence/email.repo.js';
@@ -460,7 +460,7 @@ export class EmailEventHandler {
         }
     }
 
-    private async getOrganisationKennung(organisationId: OrganisationID): Promise<Result<string>> {
+    private async getOrganisationKennung(organisationId: OrganisationID): Promise<Result<OrganisationKennung>> {
         const organisation: Option<Organisation<true>> = await this.organisationRepository.findById(organisationId);
         if (!organisation || !organisation.kennung) {
             this.logger.error(`Could not retrieve orgaKennung, orgaId:${organisationId}`);
@@ -476,7 +476,7 @@ export class EmailEventHandler {
     }
 
     private async createOrEnableEmail(personId: PersonID, organisationId: OrganisationID): Promise<void> {
-        const organisationKennung: Result<string> = await this.getOrganisationKennung(organisationId);
+        const organisationKennung: Result<OrganisationKennung> = await this.getOrganisationKennung(organisationId);
         if (!organisationKennung.ok) return;
 
         const existingEmails: EmailAddress<true>[] = await this.emailRepo.findByPersonSortedByUpdatedAtDesc(personId);
@@ -556,7 +556,7 @@ export class EmailEventHandler {
     }
 
     private async createNewEmail(personId: PersonID, organisationId: OrganisationID): Promise<void> {
-        const organisationKennung: Result<string> = await this.getOrganisationKennung(organisationId);
+        const organisationKennung: Result<OrganisationKennung> = await this.getOrganisationKennung(organisationId);
         if (!organisationKennung.ok) return;
         const personReferrer: Result<string> = await this.getPersonReferrerOrError(personId);
         if (!personReferrer.ok) {
@@ -597,7 +597,7 @@ export class EmailEventHandler {
         organisationId: OrganisationID,
         oldEmail: EmailAddress<true>,
     ): Promise<void> {
-        const organisationKennung: Result<string> = await this.getOrganisationKennung(organisationId);
+        const organisationKennung: Result<OrganisationKennung> = await this.getOrganisationKennung(organisationId);
         if (!organisationKennung.ok) return;
         const personReferrer: Result<string> = await this.getPersonReferrerOrError(personId);
         if (!personReferrer.ok) {

--- a/src/modules/ox/domain/ox-event-handler.spec.ts
+++ b/src/modules/ox/domain/ox-event-handler.spec.ts
@@ -3,7 +3,7 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigTestModule, LoggingTestModule } from '../../../../test/utils/index.js';
 import { ClassLogger } from '../../../core/logging/class-logger.js';
-import { PersonID, PersonReferrer } from '../../../shared/types/index.js';
+import { OrganisationKennung, PersonID, PersonReferrer } from '../../../shared/types/index.js';
 import { OxEventHandler } from './ox-event-handler.js';
 import { OxService } from './ox.service.js';
 import { CreateUserAction } from '../actions/user/create-user.action.js';
@@ -1313,7 +1313,7 @@ describe('OxEventHandler', () => {
         let username: string;
         let oxUserId: OXUserID;
         let oxGroupId: OXGroupID;
-        let rollenArtLehrPKOrgaKennung: string;
+        let rollenArtLehrPKOrgaKennung: OrganisationKennung;
         let event: PersonenkontextUpdatedEvent;
         let person: Person<true>;
         beforeEach(() => {

--- a/src/modules/ox/domain/ox-event-handler.ts
+++ b/src/modules/ox/domain/ox-event-handler.ts
@@ -8,7 +8,7 @@ import { DomainError } from '../../../shared/error/index.js';
 import { OxConfig } from '../../../shared/config/ox.config.js';
 import { OxService } from './ox.service.js';
 import { CreateUserAction, CreateUserParams, CreateUserResponse } from '../actions/user/create-user.action.js';
-import { PersonID, PersonReferrer } from '../../../shared/types/index.js';
+import { OrganisationKennung, PersonID, PersonReferrer } from '../../../shared/types/index.js';
 import { Person } from '../../person/domain/person.js';
 import { PersonRepository } from '../../person/persistence/person.repository.js';
 import { EmailAddressGeneratedEvent } from '../../../shared/events/email-address-generated.event.js';
@@ -455,7 +455,11 @@ export class OxEventHandler {
         return result;
     }
 
-    private async createOxUser(personId: PersonID, referrer: PersonReferrer, orgaKennung: string): Promise<void> {
+    private async createOxUser(
+        personId: PersonID,
+        referrer: PersonReferrer,
+        orgaKennung: OrganisationKennung,
+    ): Promise<void> {
         const person: Option<Person<true>> = await this.personRepository.findById(personId);
 
         if (!person) {

--- a/src/shared/types/aggregate-ids.types.ts
+++ b/src/shared/types/aggregate-ids.types.ts
@@ -9,6 +9,9 @@ export type PersonReferrer = Flavor<string, typeof personReferrerSymbol>;
 declare const organisationSymbol: unique symbol;
 export type OrganisationID = Flavor<string, typeof organisationSymbol>;
 
+declare const organisationKennungSymbol: unique symbol;
+export type OrganisationKennung = Flavor<string, typeof organisationKennungSymbol>;
+
 declare const rolleSymbol: unique symbol;
 export type RolleID = Flavor<string, typeof rolleSymbol>;
 


### PR DESCRIPTION
# Description
- instead of deleting the LDAP-user finally on PersonenkontextUpdatedEvent, rather remove LDAP-user from LDAP-group when user has no remaining PKs with rollenArt LEHR for matching organisation
- introduce OrganisationKennung as FlavoredType (currently usage in EmailEventHandler, OxEventHandler, LdapClientService)

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1703

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.