### PR TITLE
SPSH-1721: Add Keycloaks External Base-Url to fix Swagger

### DIFF
--- a/charts/dbildungs-iam-server/templates/configmap.yaml
+++ b/charts/dbildungs-iam-server/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   DEPLOY_STAGE: {{ .Values.environment | quote }}
   DB_NAME: {{ .Values.database.name | quote }}
   KC_BASE_URL: "http://{{ .Values.keycloakHostname }}"
+  KC_EXTERNAL_BASE_URL: 'https://{{ .Values.keycloakExternalHostname | replace "spsh-xxx" .Release.Namespace }}'
   FRONTEND_OIDC_CALLBACK_URL: "https://{{ .Values.backendHostname }}/api/auth/login"
   FRONTEND_DEFAULT_LOGIN_REDIRECT: "https://{{ .Values.backendHostname }}/"
   FRONTEND_LOGOUT_REDIRECT: "https://{{ .Values.backendHostname }}/"

--- a/charts/dbildungs-iam-server/values.yaml
+++ b/charts/dbildungs-iam-server/values.yaml
@@ -5,6 +5,7 @@ namespaceOverride: ''
 backendHostname: ''
 keycloakHostname: 'http://dbildungs-iam-keycloak'
 keycloak2ndHostname: ""
+keycloakExternalHostname: 'spsh-xxx-keycloak.dev.spsh.dbildungsplattform.de'
 backend2ndHostname: ""
 
 containerSecurityContext:

--- a/config/config.json
+++ b/config/config.json
@@ -24,6 +24,7 @@
     },
     "KEYCLOAK": {
         "BASE_URL": "http://localhost:8080",
+        "EXTERNAL_BASE_URL": "http://localhost:8080",
         "ADMIN_REALM_NAME": "SPSH",
         "ADMIN_CLIENT_ID": "spsh-admin",
         "REALM_NAME": "SPSH",

--- a/src/modules/health/health.controller.spec.ts
+++ b/src/modules/health/health.controller.spec.ts
@@ -24,6 +24,7 @@ describe('HealthController', () => {
         ADMIN_SECRET: '',
         ADMIN_REALM_NAME: '',
         BASE_URL: 'http://keycloak.test',
+        EXTERNAL_BASE_URL: 'http://keycloak.test',
         REALM_NAME: '',
         CLIENT_ID: '',
         CLIENT_SECRET: '',

--- a/src/modules/keycloak-administration/keycloak-instance-config.ts
+++ b/src/modules/keycloak-administration/keycloak-instance-config.ts
@@ -6,6 +6,7 @@ import { KeycloakConfig, ServerConfig } from '../../shared/config/index.js';
 export class KeycloakInstanceConfig implements KeycloakConfig {
     public constructor(
         public BASE_URL: string,
+        public EXTERNAL_BASE_URL: string,
         public ADMIN_REALM_NAME: string,
         public ADMIN_CLIENT_ID: string,
         public ADMIN_SECRET: string,
@@ -25,6 +26,7 @@ export class KeycloakInstanceConfig implements KeycloakConfig {
 
                 return new KeycloakInstanceConfig(
                     keycloakConfig.BASE_URL,
+                    keycloakConfig.EXTERNAL_BASE_URL,
                     keycloakConfig.ADMIN_REALM_NAME,
                     keycloakConfig.ADMIN_CLIENT_ID,
                     keycloakConfig.ADMIN_SECRET,

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -24,9 +24,9 @@ async function bootstrap(): Promise<void> {
             type: 'oauth2',
             flows: {
                 authorizationCode: {
-                    authorizationUrl: `${keycloakConfig.BASE_URL}/realms/${keycloakConfig.REALM_NAME}/protocol/openid-connect/auth`,
-                    tokenUrl: `${keycloakConfig.BASE_URL}/realms/${keycloakConfig.REALM_NAME}/protocol/openid-connect/token`,
-                    refreshUrl: `${keycloakConfig.BASE_URL}/realms/${keycloakConfig.REALM_NAME}/protocol/openid-connect/token`,
+                    authorizationUrl: `${keycloakConfig.EXTERNAL_BASE_URL}/realms/${keycloakConfig.REALM_NAME}/protocol/openid-connect/auth`,
+                    tokenUrl: `${keycloakConfig.EXTERNAL_BASE_URL}/realms/${keycloakConfig.REALM_NAME}/protocol/openid-connect/token`,
+                    refreshUrl: `${keycloakConfig.EXTERNAL_BASE_URL}/realms/${keycloakConfig.REALM_NAME}/protocol/openid-connect/token`,
                     scopes: {},
                 },
             },

--- a/src/shared/config/config.env.ts
+++ b/src/shared/config/config.env.ts
@@ -41,6 +41,7 @@ export default (): Config => ({
         CLIENT_SECRET: process.env['KC_CLIENT_SECRET'],
         SERVICE_CLIENT_PRIVATE_JWKS: process.env['KC_SERVICE_CLIENT_PRIVATE_JWKS'],
         BASE_URL: process.env['KC_BASE_URL'],
+        EXTERNAL_BASE_URL: process.env['KC_EXTERNAL_BASE_URL'],
     },
     LDAP: {
         URL: process.env['LDAP_URL'],

--- a/src/shared/config/config.loader.spec.ts
+++ b/src/shared/config/config.loader.spec.ts
@@ -38,6 +38,7 @@ describe('configloader', () => {
                 },
                 KEYCLOAK: {
                     BASE_URL: 'localhost:8080',
+                    EXTERNAL_BASE_URL: 'localhost:8080',
                     ADMIN_CLIENT_ID: 'admin-cli',
                     ADMIN_REALM_NAME: 'master',
                     REALM_NAME: 'schulportal',
@@ -173,6 +174,7 @@ describe('configloader', () => {
                 },
                 KEYCLOAK: {
                     BASE_URL: 'localhost:8080',
+                    EXTERNAL_BASE_URL: 'localhost:8080',
                     ADMIN_CLIENT_ID: 'admin-cli',
                     ADMIN_REALM_NAME: 'master',
                     REALM_NAME: 'schulportal',

--- a/src/shared/config/keycloak.config.ts
+++ b/src/shared/config/keycloak.config.ts
@@ -7,6 +7,10 @@ export class KeycloakConfig {
 
     @IsString()
     @IsNotEmpty()
+    public readonly EXTERNAL_BASE_URL!: string;
+
+    @IsString()
+    @IsNotEmpty()
     public readonly ADMIN_REALM_NAME!: string;
 
     @IsString()

--- a/test/config.test.json
+++ b/test/config.test.json
@@ -20,6 +20,7 @@
     },
     "KEYCLOAK": {
         "BASE_URL": "http://127.0.0.1:8080",
+        "EXTERNAL_BASE_URL": "http://127.0.0.1:8080",
         "ADMIN_REALM_NAME": "SPSH",
         "ADMIN_CLIENT_ID": "spsh-admin",
         "REALM_NAME": "SPSH",

--- a/test/utils/keycloak-config-test.module.ts
+++ b/test/utils/keycloak-config-test.module.ts
@@ -40,6 +40,7 @@ export class KeycloakConfigTestModule implements OnModuleDestroy {
 
                         return new KeycloakInstanceConfig(
                             baseUrl,
+                            keycloakConfig.EXTERNAL_BASE_URL,
                             keycloakConfig.ADMIN_REALM_NAME,
                             keycloakConfig.ADMIN_CLIENT_ID,
                             keycloakConfig.ADMIN_SECRET,


### PR DESCRIPTION
# Description
-  add KC_EXTERNAL_BASE_URL / EXTERNAL_BASE_URL to use it in Swagger-configuration

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1721

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.