### PR TITLE
SPSH-1945: Decouple LDAP-Sync and UEM-password-reset

### DIFF
--- a/src/core/ldap/domain/ldap-sync-event-handler.ts
+++ b/src/core/ldap/domain/ldap-sync-event-handler.ts
@@ -19,6 +19,7 @@ import { OrganisationRepository } from '../../../modules/organisation/persistenc
 import { RollenArt } from '../../../modules/rolle/domain/rolle.enums.js';
 import { LdapGroupKennungExtractionError } from '../error/ldap-group-kennung-extraction.error.js';
 import { OrganisationsTyp } from '../../../modules/organisation/domain/organisation.enums.js';
+import { PersonLdapSyncEvent } from '../../../shared/events/person-ldap-sync.event.js';
 
 export type LdapSyncData = {
     givenName: string;
@@ -60,6 +61,17 @@ export class LdapSyncEventHandler {
         this.logger.info(
             `[EventID: ${event.eventID}] Received PersonExternalSystemsSyncEvent, personId:${event.personId}`,
         );
+
+        await this.fetchDataAndSync(event.personId);
+    }
+
+    /**
+     * This event-handler-method is implemented to make fetchDataAndSync() callable indirectly and also avoid the usage without await.
+     * Otherwise method calls to fetchDataAndSync() had to be possible without await and would force usage floating-promises.
+     **/
+    @EventHandler(PersonLdapSyncEvent)
+    public async personLdapSyncEventHandler(event: PersonLdapSyncEvent): Promise<void> {
+        this.logger.info(`[EventID: ${event.eventID}] Received PersonLdapSyncEvent, personId:${event.personId}`);
 
         await this.fetchDataAndSync(event.personId);
     }

--- a/src/shared/events/person-ldap-sync.event.ts
+++ b/src/shared/events/person-ldap-sync.event.ts
@@ -1,0 +1,13 @@
+import { BaseEvent } from './base-event.js';
+import { PersonID } from '../types/index.js';
+
+/**
+ * Used for triggering syncing information about a person from SPSH to LDAP explicitly
+ * and avoid communication and syncing to other systems like publishing an instance of
+ * PersonExternalSystemsSyncEvent would do.
+ */
+export class PersonLdapSyncEvent extends BaseEvent {
+    public constructor(public readonly personId: PersonID) {
+        super();
+    }
+}


### PR DESCRIPTION
# Description
- adds new Event PersonLdapSyncEvent for decoupling LDAP-sync and UEM-password-reset, advantages:
  - floating promises can be avoided
  - explicit LDAP-sync without syncing all other systems is possible 

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1945

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.