### PR TITLE
SPSH-1944: Introduce method "logUnknownAsError" in ClassLogger and use it for error-logging and error-serialization in LdapClientService instead of JSON.stringify

### DIFF
--- a/src/core/ldap/domain/ldap-client.service.spec.ts
+++ b/src/core/ldap/domain/ldap-client.service.spec.ts
@@ -858,6 +858,7 @@ describe('LDAP Client Service', () => {
             });
 
             it('when adding fails should log error', async () => {
+                const error: Error = new Error('LDAP-Error');
                 ldapClientMock.getClient.mockImplementation(() => {
                     clientMock.bind.mockResolvedValue();
                     clientMock.bind.mockResolvedValue();
@@ -868,7 +869,7 @@ describe('LDAP Client Service', () => {
                     clientMock.search.mockResolvedValueOnce(createMock<SearchResult>({ searchEntries: [] }));
                     clientMock.search.mockResolvedValueOnce(createMock<SearchResult>({ searchEntries: [] }));
                     clientMock.add.mockResolvedValueOnce();
-                    clientMock.add.mockRejectedValueOnce(new Error('LDAP-Error'));
+                    clientMock.add.mockRejectedValueOnce(error);
 
                     return clientMock;
                 });
@@ -887,8 +888,9 @@ describe('LDAP Client Service', () => {
                 );
 
                 if (result.ok) throw Error();
-                expect(loggerMock.error).toHaveBeenCalledWith(
-                    `LDAP: Creating lehrer FAILED, uid:${lehrerUid}, errMsg:{}`,
+                expect(loggerMock.logUnknownAsError).toHaveBeenCalledWith(
+                    `LDAP: Creating lehrer FAILED, uid:${lehrerUid}`,
+                    error,
                 );
                 expect(result.error).toEqual(new LdapCreateLehrerError());
             });
@@ -1829,6 +1831,7 @@ describe('LDAP Client Service', () => {
             const currentEmailAddress: string = 'current-address@schule-sh.de';
 
             it('should set mailAlternativeAddress as current mailPrimaryAddress and throw LdapPersonEntryChangedEvent', async () => {
+                const error: Error = new Error();
                 ldapClientMock.getClient.mockImplementation(() => {
                     clientMock.bind.mockResolvedValueOnce();
                     clientMock.search.mockResolvedValueOnce(
@@ -1854,8 +1857,9 @@ describe('LDAP Client Service', () => {
 
                 if (result.ok) throw Error();
                 expect(result.error).toStrictEqual(new LdapModifyEmailError());
-                expect(loggerMock.error).toHaveBeenCalledWith(
-                    `LDAP: Modifying mailPrimaryAddress and mailAlternativeAddress FAILED, errMsg:{}`,
+                expect(loggerMock.logUnknownAsError).toHaveBeenCalledWith(
+                    `LDAP: Modifying mailPrimaryAddress and mailAlternativeAddress FAILED`,
+                    error,
                 );
                 expect(eventServiceMock.publish).toHaveBeenCalledTimes(0);
             });
@@ -2412,6 +2416,7 @@ describe('LDAP Client Service', () => {
             const fakeDN: string = faker.string.alpha();
 
             it('should NOT publish event and throw LdapPersonEntryChangedEvent', async () => {
+                const error: Error = new Error();
                 ldapClientMock.getClient.mockImplementation(() => {
                     clientMock.bind.mockResolvedValueOnce();
                     clientMock.search.mockResolvedValueOnce(
@@ -2423,7 +2428,7 @@ describe('LDAP Client Service', () => {
                             ],
                         }),
                     );
-                    clientMock.modify.mockRejectedValueOnce(new Error());
+                    clientMock.modify.mockRejectedValueOnce(error);
 
                     return clientMock;
                 });
@@ -2435,8 +2440,9 @@ describe('LDAP Client Service', () => {
 
                 if (result.ok) throw Error();
                 expect(result.error).toStrictEqual(new LdapModifyUserPasswordError());
-                expect(loggerMock.error).toHaveBeenCalledWith(
-                    `LDAP: Modifying userPassword (UEM) FAILED for personId:${fakePersonID}, referrer:${fakeReferrer}, errMsg:{}`,
+                expect(loggerMock.logUnknownAsError).toHaveBeenCalledWith(
+                    `LDAP: Modifying userPassword (UEM) FAILED for personId:${fakePersonID}, referrer:${fakeReferrer}`,
+                    error,
                 );
                 expect(eventServiceMock.publish).toHaveBeenCalledTimes(0);
             });

--- a/src/core/ldap/domain/ldap-client.service.ts
+++ b/src/core/ldap/domain/ldap-client.service.ts
@@ -241,9 +241,9 @@ export class LdapClientService {
                 value: true,
             };
         } catch (err) {
-            const errMsg: string = `Could not connect to LDAP, message: ${JSON.stringify(err)}`;
-            this.logger.error(errMsg);
-            return { ok: false, error: new Error(errMsg) };
+            this.logger.logUnknownAsError(`Could not connect to LDAP`, err);
+
+            return { ok: false, error: new Error('LDAP bind FAILED') };
         }
     }
 
@@ -350,8 +350,8 @@ export class LdapClientService {
 
                 return { ok: true, value: person };
             } catch (err) {
-                const errMsg: string = JSON.stringify(err);
-                this.logger.error(`LDAP: Creating lehrer FAILED, uid:${lehrerUid}, errMsg:${errMsg}`);
+                this.logger.logUnknownAsError(`LDAP: Creating lehrer FAILED, uid:${lehrerUid}`, err);
+
                 return { ok: false, error: new LdapCreateLehrerError() };
             }
         });
@@ -776,8 +776,8 @@ export class LdapClientService {
 
                 return { ok: true, value: person };
             } catch (err) {
-                const errMsg: string = JSON.stringify(err);
-                this.logger.error(`LDAP: Deleting lehrer FAILED, uid:${lehrerUid}, errMsg:${errMsg}`);
+                this.logger.logUnknownAsError(`LDAP: Deleting lehrer FAILED, uid:${lehrerUid}`, err);
+
                 return { ok: false, error: new LdapCreateLehrerError() };
             }
         });
@@ -864,9 +864,9 @@ export class LdapClientService {
 
                 return { ok: true, value: personId };
             } catch (err) {
-                const errMsg: string = JSON.stringify(err);
-                this.logger.error(
-                    `LDAP: Modifying mailPrimaryAddress and mailAlternativeAddress FAILED, errMsg:${errMsg}`,
+                this.logger.logUnknownAsError(
+                    `LDAP: Modifying mailPrimaryAddress and mailAlternativeAddress FAILED`,
+                    err,
                 );
 
                 return { ok: false, error: new LdapModifyEmailError() };
@@ -1078,9 +1078,9 @@ export class LdapClientService {
 
                 return { ok: true, value: userPassword };
             } catch (err) {
-                const errMsg: string = JSON.stringify(err);
-                this.logger.error(
-                    `LDAP: Modifying userPassword (UEM) FAILED for personId:${personId}, referrer:${referrer}, errMsg:${errMsg}`,
+                this.logger.logUnknownAsError(
+                    `LDAP: Modifying userPassword (UEM) FAILED for personId:${personId}, referrer:${referrer}`,
+                    err,
                 );
 
                 return { ok: false, error: new LdapModifyUserPasswordError() };


### PR DESCRIPTION
# Description
- introduce method _logUnknownAsError(message: string, error: unknown)_ in ClassLogger 
- in LdapClientService: replace former serialization of "unknow" errors (any type) via JSON.stringify with calling new _logUnknownAsError(message: string, error: unknown)_ 

## Links to Tickets or other pull requests
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1944
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1957


## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.