### PR TITLE
SPSH-1967: GET personen (alle) Endpunkt liefert Email-Adresse nicht in Response

### DIFF
--- a/src/modules/person/api/person.controller.ts
+++ b/src/modules/person/api/person.controller.ts
@@ -329,11 +329,18 @@ export class PersonController {
 
         const [persons, total]: Counted<Person<true>> = await this.personRepository.findBy(scope);
 
+        const personIds: PersonID[] = persons.map((p: Person<true>) => p.id);
+        const personEmailResponseMap: Map<PersonID, PersonEmailResponse> =
+            await this.emailRepo.getEmailAddressAndStatusForPersonIds(personIds);
+
         const response: PagedResponse<PersonendatensatzResponse> = new PagedResponse({
             offset: queryParams.offset ?? 0,
             limit: queryParams.limit ?? total,
             total: total,
-            items: persons.map((person: Person<true>) => new PersonendatensatzResponse(person, false)),
+            items: persons.map(
+                (person: Person<true>) =>
+                    new PersonendatensatzResponse(person, false, personEmailResponseMap.get(person.id)),
+            ),
         });
 
         return response;


### PR DESCRIPTION
# Description
Gathering information about email-address and status only happened when fetching a single person via GET :personID.

- add new method for fetching several EmailAddresses from DB for a list of personIds in the EmailRepo
- adjusted PersonController to also attach the latest enabled EmailAddress for a person if any, when fetching persons via GET

## Links to Tickets or other pull requests
<!--
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-1967

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.