### PR TITLE
SPSH-2622: use updateMetadata instead of save, so lock is removed

### DIFF
--- a/src/modules/person/persistence/person.repository.ts
+++ b/src/modules/person/persistence/person.repository.ts
@@ -62,6 +62,7 @@ import { PersonExternalIdMappingEntity } from './external-id-mappings.entity.js'
 import { PersonEntity } from './person.entity.js';
 import { PersonScope } from './person.scope.js';
 import { RollenSystemRecht } from '../../rolle/domain/systemrecht.js';
+import { IPersonPermissions } from '../../../shared/permissions/person-permissions.interface.js';
 
 /**
  * Return email-address for person, if an enabled email-address exists, return it.
@@ -940,7 +941,7 @@ export class PersonRepository {
         personalnummer: string | undefined,
         lastModified: Date,
         revision: string,
-        permissions: PersonPermissions,
+        permissions: IPersonPermissions,
     ): Promise<Person<true> | DomainError> {
         const personFound: Option<Person<true>> = await this.findById(personId);
         if (!personFound) {

--- a/src/modules/personenkontext/domain/personenkontexte-update.spec.ts
+++ b/src/modules/personenkontext/domain/personenkontexte-update.spec.ts
@@ -624,7 +624,7 @@ describe('PersonenkontexteUpdate', () => {
                 );
                 await sut.update();
 
-                expect(personRepoMock.save).toHaveBeenCalledTimes(1);
+                expect(personRepoMock.updatePersonMetadata).toHaveBeenCalledTimes(1);
             });
         });
         describe('when existing personenkontexte have one personenkontext with rollenart LERN', () => {
@@ -799,7 +799,7 @@ describe('PersonenkontexteUpdate', () => {
                 const saveError: DuplicatePersonalnummerError = new DuplicatePersonalnummerError(
                     'PERSONALNUMMER_SAVE_ERROR',
                 );
-                personRepoMock.save.mockResolvedValue(saveError);
+                personRepoMock.updatePersonMetadata.mockResolvedValue(saveError);
 
                 const updateResult: Personenkontext<true>[] | DuplicatePersonalnummerError = await sut.update();
 

--- a/src/modules/personenkontext/domain/personenkontexte-update.ts
+++ b/src/modules/personenkontext/domain/personenkontexte-update.ts
@@ -364,10 +364,17 @@ export class PersonenkontexteUpdate {
         if (this.personalnummer) {
             const person: Option<Person<true>> = await this.personRepo.findById(this.personId);
             if (person) {
-                person.personalnummer = this.personalnummer;
-                const saveResult: DomainError | Person<true> = await this.personRepo.save(person);
-                if (saveResult instanceof DomainError) {
-                    return saveResult;
+                const updateResult: Person<true> | DomainError = await this.personRepo.updatePersonMetadata(
+                    person.id,
+                    person.familienname,
+                    person.vorname,
+                    this.personalnummer,
+                    person.updatedAt,
+                    person.revision,
+                    this.permissions,
+                );
+                if (updateResult instanceof DomainError) {
+                    return updateResult;
                 }
             }
         }
@@ -388,7 +395,7 @@ export class PersonenkontexteUpdate {
             }
         } else {
             const person: Option<Person<true>> = await this.personRepo.findById(this.personId);
-            if (person && person.orgUnassignmentDate) {
+            if (person?.orgUnassignmentDate) {
                 person.orgUnassignmentDate = undefined;
                 await this.personRepo.save(person);
             }


### PR DESCRIPTION
# Description
- use updateMetadata instead of save, so lock is removed

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/dBildungsplattform/dbildungs-iam-server/pulls
- https://ticketsystem.dbildungscloud.de/browse/SPSH-???
- https://ticketsystem.dbildungscloud.de/browse/EW-???
-->
https://ticketsystem.dbildungscloud.de/browse/SPSH-2622

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
<!--
  Notice about:
  - model changes
  - logging of user data
  - permission changes
  - and other sensitive user related data
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  - Keep in mind to change seed data, if changes are done on migration scripts.
  - Mention what is required for deployment after changes on infrastructure and inform SRE about it
  - Explain changes on the config schema, which need to be addressed regarding the impact on helm charts 
  - Mention Migration scripts to run, or other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.
  Check licenses and have it cleared.

  Describe why it is needed.
-->

## Approval for review
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.