### PR TITLE
DBP-1690-align kafka initContainer and volume conditions

### DIFF
--- a/charts/dbildungs-iam-server/templates/backend-deployment.yaml
+++ b/charts/dbildungs-iam-server/templates/backend-deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - name: secret-volume
           secret:
             secretName: {{ default .Values.auth.existingSecret .Values.auth.secretName }}
-        {{if .Values.kafka.enabled }}
+        {{if .Values.kafka.initEnabled }}
         - name: kafka-init-volume
           configMap:
             name: {{ template "common.names.name" $ }}-kafka-init-configmap


### PR DESCRIPTION
Previously, initContainer was controlled
by `kafka.initEnabled` while the volume was gated by `kafka.enabled`,
causing deployment failures with "volume not found"

https://github.com/dBildungsplattform/spsh-app-release/actions/runs/18121914632

Solution:
https://github.com/dBildungsplattform/spsh-app-release/actions/runs/18123589872
